### PR TITLE
add soundness proof

### DIFF
--- a/src/Sound/Data/Ast/Expr.dfy
+++ b/src/Sound/Data/Ast/Expr.dfy
@@ -1,0 +1,816 @@
+module Expr {
+  import opened Utils
+  import opened State
+  import M = Model
+  import opened Std.Wrappers
+
+  datatype Operator =
+    // ternary operators
+    | IfThenElse
+    // binary operators
+    | Equiv
+    | LogicalImp
+    | LogicalAnd | LogicalOr
+    | Eql | Neql
+    | Less | AtMost
+    | Plus | Minus | Times | Div | Mod
+    // unary operators
+    | LogicalNot
+    | UnaryMinus
+  {
+    function Type(): M.Type 
+      requires !IfThenElse?
+      requires !Eql?
+      requires !Neql?
+    {
+      match this {
+        case LogicalNot | Equiv | LogicalImp | LogicalAnd | LogicalOr => M.Bool
+        case _ => M.Int
+      }
+    }
+
+    function Arity() : nat {
+      match this
+      case IfThenElse => 3
+      case LogicalNot | UnaryMinus => 1
+      case _ => 2
+    }
+
+    function ToBinaryFunc(m: M.Model): (M.Any, M.Any) --> M.Any
+      requires Arity() == 2
+    {
+      match this {
+        case Equiv => m.Equiv
+        case LogicalImp => m.Implies
+        case LogicalAnd => m.LogicAnd
+        case LogicalOr => m.Or
+        case Eql => m.Eql
+        case Neql => m.Neql
+        case Less => m.Less
+        case AtMost => m.AtMost
+        case Plus => m.Plus
+        case Minus => m.Minus
+        case Times => m.Times
+        case Div => m.Div
+        case Mod => m.Mod
+      }
+    }
+
+    function ToUnaryFunc(m: M.Model): M.Any --> M.Any
+      requires Arity() == 1
+    {
+      match this {
+        case LogicalNot => m.Not
+        case UnaryMinus => m.Negate
+      }
+    }
+
+    predicate CompatibleWith(args: seq<M.Any>, m: M.Model) {
+      |args| == Arity() &&
+      match this
+      case IfThenElse => m.IsBool(args[0])
+      case Eql | Neql => true 
+      case _ => 
+        if Type() == M.Int then
+          && (forall i :: 0 <= i < |args| ==> m.IsInt(args[i]))
+          && (Div? || Mod? ==> m.ToInt(args[1]) != 0)
+        else if Type() == M.Bool then
+          forall i :: 0 <= i < |args| ==> m.IsBool(args[i])
+        else false
+    }
+
+    opaque function Eval(args: seq<M.Any>, m: M.Model): Option<M.Any>
+    {
+      if !CompatibleWith(args, m) then None
+      else if Arity() == 3 then
+        if m.IsBool(args[0]) then Some(args[0]) else Some(args[1])
+      else if Arity() == 1 then
+        Some(ToUnaryFunc(m)(args[0]))
+      else if Arity() == 2 then
+        Some(ToBinaryFunc(m)(args[0], args[1]))
+      else None
+    }
+
+    greatest predicate RefEval(args: seq<M.Any>, outs: iset<M.Any>, m: M.Model)
+    {
+      Eval(args, m).Some? && Eval(args, m).value in outs
+    }
+  }
+
+  lemma EqlEvalLemma(v1: M.Any, v2: M.Any, m: M.Model)
+    ensures Eql.Eval([v1, v2], m) == Some(m.InterpBool(v1 == v2))
+  {
+    reveal Eql.Eval;
+  }
+
+  lemma AndEvalLemma(v1: M.Any, v2: M.Any, m: M.Model)
+    requires m.IsBool(v1)
+    requires m.IsBool(v2)
+    ensures LogicalAnd.Eval([v1, v2], m) == Some(m.LogicAnd(v1, v2))
+  {
+    reveal LogicalAnd.Eval;
+  }
+
+  lemma ImpliesEvalLemma(v1: M.Any, v2: M.Any, m: M.Model)
+    requires m.IsBool(v1)
+    ensures LogicalImp.Eval([v1, v2], m) == 
+      if m.IsBool(v2) then Some(m.Implies(v1, v2)) else None
+  {
+    reveal LogicalImp.Eval;
+  }
+
+  datatype Literal = Literal(value: string, typ: Type) {
+    function ToLiteral(): M.Literal {
+      M.Literal(value, typ.ToType())
+    }
+  }
+
+  type FParameter = Variable
+
+  datatype FunctionDefinition = FunctionDefinition(when: seq<Expr>, body: Expr)
+
+  class Function {
+    const Name: string
+    const Parameters: seq<FParameter>
+    const ResultType: Type
+    var Definition: Option<FunctionDefinition>
+
+    predicate HasBody() 
+      reads this`Definition
+    {
+      Definition.Some?
+    }
+
+    function GetDef(): Expr
+      requires HasBody()
+      reads this`Definition
+    {
+      Definition.value.body
+    }
+
+    predicate ArgsCompatibleWith(args: seq<M.Any>, m: M.Model) {
+      |args| == |Parameters| && forall i :: 0 <= i < |args| ==> m.HasType(args[i], Parameters[i].typ.ToType())
+    }
+
+    function ToFunction(): M.Function {
+      M.Function(Name, seq(|Parameters|, (i: nat) requires i < |Parameters| => Parameters[i].typ.ToType()), ResultType.ToType())
+    }
+
+    predicate Valid()
+      reads *
+    {
+      HasBody() ==> GetDef().IsDefinedOn(SetOfSeq(Parameters))
+    }
+
+    function FunctionsCalled(): set<Function>
+      reads *
+    {
+      if HasBody() then GetDef().FunctionsCalled() else {}
+    }
+
+    function EvalArgs(args: seq<M.Any>, m: M.Model): Option<M.Any> {
+      if ArgsCompatibleWith(args, m) then 
+        Some(m.InterpFunctionOn(ToFunction(), args)) 
+      else None
+    }
+
+    function ToState'(args: seq<M.Any>, params: seq<FParameter>): State 
+      requires |args| == |params|
+    {
+      if params == [] then map[] else 
+        map[params[0] := args[0]] + ToState'(args[1..], params[1..])
+    }
+
+    function ToState(args: seq<M.Any>): State 
+      requires |args| == |Parameters|
+    {
+      ToState'(args, Parameters)
+    }
+
+    greatest predicate RefEval(args: seq<M.Any>, outs: iset<M.Any>, m: M.Model)
+      reads *
+    {
+      && ArgsCompatibleWith(args, m)
+      && var fval := m.InterpFunctionOn(ToFunction(), args);
+        && fval in outs
+        && (HasBody() ==> GetDef().RefEval(ToState(args), iset{fval}, m))
+    }
+
+    ghost predicate IsSound(m: M.Model)
+      // requires Valid()
+      reads *
+    {
+      HasBody() ==> 
+        forall args: seq<M.Any> | ArgsCompatibleWith(args, m) :: 
+          GetDef().RefEval(ToState(args), iset{m.InterpFunctionOn(ToFunction(), args)}, m)
+    }
+
+    lemma EvalSound(args: seq<M.Any>, funs: set<Function>, outs: iset<M.Any>, m: M.Model)
+      requires EvalArgs(args, m).Some?
+      requires forall func <- funs :: func.IsSound(m)
+      requires forall func <- funs :: func.FunctionsCalled() <= funs
+      requires this in funs
+      requires EvalArgs(args, m).value in outs
+      ensures RefEval(args, outs, m)
+    {
+      if HasBody() {
+        assert ArgsCompatibleWith(args, m);
+        // GetDef().EvalSound(ToState(args), funs);
+        // calc {
+        //   RefEval(args, iset{EvalArgs(args).value});
+        //   == 
+        //   GetDef().RefEval(ToState(args), iset{EvalArgs(args).value});
+        // }
+      }
+    }
+  }
+
+  datatype Expr =
+    | BConst(bvalue: bool)
+    | IConst(ivalue: int)
+    | CustomConst(value: Literal)
+    | BVar(v: Variable)
+    | OperatorExpr(op: Operator, args: seq<Expr>)
+    | FunctionCallExpr(func: Function, args: seq<Expr>)
+    | LetExpr(v: Variable, rhs: Expr, body: Expr)
+    | QuantifierExpr(univ: bool, v: Variable, body: Expr) 
+  {
+    function FVars(): set<Variable>
+    {
+      match this
+      case BConst(_) => {}
+      case IConst(_) => {}
+      case CustomConst(_) => {}
+      case BVar(v) => {v}
+      case OperatorExpr(op, args) => SeqExprFVars(args)
+      case FunctionCallExpr(func, args) => SeqExprFVars(args)
+      case LetExpr(v, rhs, body) => rhs.FVars() + (body.FVars() - {v})
+      case QuantifierExpr(univ, v, body) => body.FVars() - {v}
+    }
+
+    predicate IsDefinedOn(vars: set<Variable>) 
+    {
+      FVars() <= vars
+    }
+
+    function FunctionsCalled(): set<Function>
+    {
+      match this
+      case FunctionCallExpr(func, args) => {func} + SeqExprFunctionsCalled(args)
+      case OperatorExpr(op, args) => SeqExprFunctionsCalled(args)
+      case QuantifierExpr(univ, v, body) => body.FunctionsCalled()
+      case LetExpr(v, rhs, body) => rhs.FunctionsCalled() + body.FunctionsCalled()
+      case _ => {}
+    }
+
+    predicate ValidCalls()
+      reads *
+    {
+      forall func <- FunctionsCalled() :: func.Valid()
+    }
+
+    ghost function Eval(s: State, m: M.Model): Option<M.Any>
+      requires IsDefinedOn(s.Keys)
+    {
+      match this
+      case BConst(bvalue)  => Some(m.InterpBool(bvalue))
+      case IConst(ivalue)  => Some(m.InterpInt(ivalue))
+      case BVar(id) => Some(s[id])
+      case CustomConst(value) => Some(m.InterpLiteral(value.ToLiteral()))
+      case OperatorExpr(op, args) => 
+        var args :- SeqEval(args, s, m);
+        op.Eval(args, m)
+      case FunctionCallExpr(func, args) => 
+        var args :- SeqEval(args, s, m);
+        func.EvalArgs(args, m)
+      case QuantifierExpr(true, v, body) =>
+        if (forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            SomeBVal?(body.Eval(s.UpdateAt(v, x), m), m)) then 
+          Some(m.InterpBool(forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            body.Eval(s.UpdateAt(v, x), m) == Some(m.True())
+          ))
+        else None
+      case QuantifierExpr(false, v, body) =>
+        if (forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            SomeBVal?(body.Eval(s.UpdateAt(v, x), m), m)) then 
+          Some(m.InterpBool(exists x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            body.Eval(s.UpdateAt(v, x), m) == Some(m.True())
+          ))
+        else None
+      case LetExpr(v, rhs, body) => 
+        var x :- rhs.Eval(s, m);
+        body.Eval(s.UpdateAt(v, x), m)
+    }
+
+    greatest predicate RefEval(s: State, outs: iset<M.Any>, m: M.Model)
+      reads *
+    {
+      match this
+      case BConst(bvalue) => m.InterpBool(bvalue) in outs
+      case IConst(ivalue) => m.InterpInt(ivalue) in outs
+      case CustomConst(value) => m.InterpLiteral(value.ToLiteral()) in outs
+      case BVar(id) => v in s.Keys && s[id] in outs
+      case OperatorExpr(op, args) => 
+        exists outArgsSet: seq<iset<M.Any>> :: 
+          && RefSeqEval(args, s, outArgsSet, m)
+          && forall outArgs <- CrossProduct(outArgsSet) :: op.RefEval(outArgs, outs, m)
+      case FunctionCallExpr(func, args) => 
+        exists outArgsSet: seq<iset<M.Any>> :: 
+          && RefSeqEval(args, s, outArgsSet, m)
+          && forall outArgs <- CrossProduct(outArgsSet) :: func.RefEval(outArgs, outs, m)
+      case LetExpr(v, rhs, body) => 
+        exists outsRhs: iset<M.Any> :: 
+          && rhs.RefEval(s, outsRhs, m)
+          && forall out <- outsRhs :: body.RefEval(s.UpdateAt(v, out), outs, m)
+      case QuantifierExpr(true, v, body) => 
+        (forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            body.RefEval(s.UpdateAt(v, x), (iset v | m.IsBool(v)), m))
+        &&
+        ((m.True() in outs &&
+          forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            body.RefEval(s.UpdateAt(v, x), iset{m.True()}, m))
+        ||
+        (m.False() in outs &&
+          exists x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            body.RefEval(s.UpdateAt(v, x), iset{m.False()}, m)))
+      case QuantifierExpr(false, v, body) =>
+        (forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            body.RefEval(s.UpdateAt(v, x), (iset v | m.IsBool(v)), m))
+        &&
+        ((m.True() in outs &&
+          exists x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            body.RefEval(s.UpdateAt(v, x), iset{m.True()}, m))
+        ||
+        (m.False() in outs &&
+          forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+            body.RefEval(s.UpdateAt(v, x), iset{m.False()}, m)))
+    }
+
+    ghost predicate LetRefEval(s: State, u: Variable, rhs: Expr, body: Expr, outsRhs: iset<M.Any>, outs: iset<M.Any>, m: M.Model)
+      reads *
+    {
+      forall out <- outsRhs :: body.RefEval(s.UpdateAt(u, out), outs, m)
+    }
+
+    lemma LetRefEvalUnfold(s: State, rhs: Expr, body: Expr, outs: iset<M.Any>, v: Variable, m: M.Model) returns (outsRhs: iset<M.Any>)
+      requires LetExpr(v, rhs, body).RefEval(s, outs, m)
+      ensures rhs.RefEval(s, outsRhs, m)
+      ensures forall out <- outsRhs :: body.RefEval(s.UpdateAt(v, out), outs, m)
+    {
+      var outsRhs' :| rhs.RefEval(s, outsRhs', m) &&
+        LetRefEval(s, v, rhs, body, outsRhs', outs, m);
+      outsRhs := outsRhs';
+      forall out | out in outsRhs ensures body.RefEval(s.UpdateAt(v, out), outs, m) {
+        assert LetRefEval(s, v, rhs, body, outsRhs, outs, m) ==> forall out <- outsRhs :: body.RefEval(s.UpdateAt(v, out), outs, m);
+      }
+    }
+
+    lemma EvalComplete(s: State, outs: iset<M.Any>, m: M.Model)
+      requires RefEval(s, outs, m)
+      // ensures outs != iset{}
+      ensures IsDefinedOn(s.Keys)
+      ensures Eval(s, m).Some? 
+      ensures Eval(s, m).value in outs
+    {
+      match this
+      case OperatorExpr(op, args) => 
+        var outArgsSet :| 
+          && RefSeqEval(args, s, outArgsSet, m)
+          && (forall outArgs <- CrossProduct(outArgsSet) :: op.RefEval(outArgs, outs, m));
+        SeqEvalComplete(args, s, outArgsSet, m);
+      case FunctionCallExpr(func, args) => 
+        var outArgsSet :| 
+          && RefSeqEval(args, s, outArgsSet, m)
+          && (forall outArgs <- CrossProduct(outArgsSet) :: func.RefEval(outArgs, outs, m));
+        SeqEvalComplete(args, s, outArgsSet, m);
+      case LetExpr(v, rhs, body) => 
+        var outsRhs := LetRefEvalUnfold(s, rhs, body, outs, v, m);
+        rhs.EvalComplete(s, outsRhs, m);
+      case QuantifierExpr(true, v, body) => 
+        var x := m.NoEmptyTypes(v.typ.ToType());
+        if (forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+          body.RefEval(s.UpdateAt(v, x), iset{m.True()}, m)) {
+        }
+      case QuantifierExpr(false, v, body) => 
+        var x := m.NoEmptyTypes(v.typ.ToType());
+        if (exists x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+          body.RefEval(s.UpdateAt(v, x), iset{m.True()}, m)) {
+        }
+      case _ => 
+    }
+
+    lemma EvalSound(s: State, funs: set<Function>, outs: iset<M.Any>, m: M.Model)
+      requires FunctionsCalled() <= funs
+      requires forall func <- funs :: func.IsSound(m)
+      requires forall func <- funs :: func.FunctionsCalled() <= funs
+      requires IsDefinedOn(s.Keys)
+      requires Eval(s, m).Some?
+      requires Eval(s, m).value in outs
+      ensures RefEval(s, outs, m)
+    {
+      match this
+      case OperatorExpr(op, args) => 
+        SeqEvalSound(args, s, funs, SeqSingleton(SeqEval(args, s, m).value), m);
+        CrossProductSeqSingleton(SeqEval(args, s, m).value);
+      case FunctionCallExpr(func, args) => 
+        SeqEvalSound(args, s, funs, SeqSingleton(SeqEval(args, s, m).value), m);
+        CrossProductSeqSingleton(SeqEval(args, s, m).value);
+        func.EvalSound(SeqEval(args, s, m).value, funs, outs, m );
+      case LetExpr(v, rhs, body) => rhs.EvalSound(s, funs, iset{rhs.Eval(s, m).value}, m);
+      case QuantifierExpr(true, v, body) => 
+        assert forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+          SomeBVal?(body.Eval(s.UpdateAt(v, x), m), m);
+        if !(forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+          body.Eval(s.UpdateAt(v, x), m) == Some(m.True())) {
+          var x: M.Any :| m.HasType(x, v.typ.ToType()) &&
+            body.Eval(s.UpdateAt(v, x), m) != Some(m.True());
+          m.BoolIsTrueOrFalse(body.Eval(s.UpdateAt(v, x), m).value);
+        }
+      case QuantifierExpr(false, v, body) => 
+        assert forall x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+          SomeBVal?(body.Eval(s.UpdateAt(v, x), m), m);
+        if !(exists x: M.Any | m.HasType(x, v.typ.ToType()) :: 
+          body.Eval(s.UpdateAt(v, x), m) == Some(m.True())) {
+          forall x: M.Any | m.HasType(x, v.typ.ToType()) {
+            m.BoolIsTrueOrFalse(body.Eval(s.UpdateAt(v, x), m).value);
+          }
+        }
+      case _ =>
+    }
+
+    ghost predicate HoldsOn(s: State, m: M.Model) 
+      requires IsDefinedOn(s.Keys)
+    {
+      Eval(s, m) == Some(m.True())
+    }
+
+    ghost predicate Holds(md: M.Model) {
+      forall s: State :: IsDefinedOn(s.Keys) ==> HoldsOn(s, md)
+    }
+
+
+    ghost predicate RefHoldsOn(s: State, m: M.Model)
+      reads *
+    {
+      RefEval(s, iset{m.True()}, m)
+    }
+
+    lemma HoldsOnSound(s: State, funs: set<Function>, m: M.Model)
+      requires FunctionsCalled() <= funs
+      requires forall func <- funs :: func.IsSound(m)
+      requires forall func <- funs :: func.FunctionsCalled() <= funs
+      ensures (IsDefinedOn(s.Keys) && HoldsOn(s, m)) == RefHoldsOn(s, m)
+    {
+      if IsDefinedOn(s.Keys) && HoldsOn(s, m) {
+        EvalSound(s, funs, iset{m.True()}, m);
+      }
+      if RefHoldsOn(s, m) {
+        EvalComplete(s, iset{m.True()}, m);
+      }
+    }
+
+    lemma EvalFVarsLemma(s1: State, s2: State, m: M.Model) 
+      requires IsDefinedOn(s1.Keys)
+      requires IsDefinedOn(s2.Keys)
+      requires forall v: Variable :: v in FVars() ==> s1[v] == s2[v]
+      ensures Eval(s1, m) == Eval(s2, m)
+    { 
+      match this
+      case QuantifierExpr(true, v, body) => 
+      case QuantifierExpr(false, v, body) => 
+      case FunctionCallExpr(func, args) => SeqEvalFVarsLemma(args, s1, s2, m);
+      case OperatorExpr(op, args) => SeqEvalFVarsLemma(args, s1, s2, m);
+      case _ => 
+    } 
+
+    ghost predicate RefHolds(md: M.Model)
+      reads *
+    {
+      forall s: State :: IsDefinedOn(s.Keys) ==> RefHoldsOn(s, md)
+    }
+
+    ghost function Sem(m: M.Model): iset<State> 
+    { 
+      iset st: State | IsDefinedOn(st.Keys) && HoldsOn(st, m) 
+    }
+
+    ghost predicate IsSafe(m: M.Model) {
+      forall s: State | IsDefinedOn(s.Keys) :: Eval(s, m).Some?
+    }
+  }
+
+  ghost predicate SeqHolds(ss: seq<Expr>, md: M.Model)
+  {
+    forall e <- ss :: e.Holds(md)
+  }
+
+  ghost predicate SeqRefHolds(ss: seq<Expr>, md: M.Model)
+    reads *
+  {
+    forall e <- ss :: e.RefHolds(md)
+  }
+
+  ghost predicate SeqRefHoldsWith(ss: seq<Expr>, funs: set<Function>)
+    reads *
+  {
+    forall md: M.Model ::
+      (forall func <- funs :: func.IsSound(md)) ==> SeqRefHolds(ss, md)
+  }
+
+  function SeqExprFunctionsCalled(ss: seq<Expr>): set<Function>
+  {
+    if ss == [] then {} else ss[0].FunctionsCalled() + SeqExprFunctionsCalled(ss[1..])
+  }
+
+  lemma SeqExprFunctionsCalledIn(ss: seq<Expr>, s: Expr)
+    requires s in ss
+    ensures s.FunctionsCalled() <= SeqExprFunctionsCalled(ss)
+  {
+  }
+
+  ghost function CrossProduct<T(!new)>(ss: seq<iset<T>>): iset<seq<T>> {
+    iset s | 
+      && |s| == |ss|
+      && forall i: nat | i < |ss| :: s[i] in ss[i]
+  }
+
+  function SeqSingleton(s: seq): seq<iset> {
+    seq(|s|, (i: nat) requires i < |s| => iset{s[i]})
+  }
+
+  lemma SeqSingletonCons<T>(s: T, ss: seq)
+    ensures SeqSingleton([s] + ss) == [iset{s}] + SeqSingleton(ss)
+  { }
+
+  lemma CrossProductSeqSingleton<T(!new)>(ss: seq)
+    ensures CrossProduct(SeqSingleton(ss)) == iset{ss}
+  {
+    forall s <- CrossProduct(SeqSingleton(ss)) ensures s == ss { }
+  }
+
+  greatest predicate RefSeqEval(ss: seq<Expr>, s: State, outSeqs: seq<iset<M.Any>>, m: M.Model) 
+    reads *
+  {
+    if ss == [] then outSeqs == [] else
+    && |outSeqs| > 0
+    && ss[0].RefEval(s, outSeqs[0], m)
+    && RefSeqEval(ss[1..], s, outSeqs[1..], m)
+  }
+
+  ghost function SeqEval(ss: seq<Expr>, s: State, m: M.Model): Option<seq<M.Any>>
+    requires SeqExprFVars(ss) <= s.Keys
+    ensures SeqEval(ss, s, m).Some? ==> |SeqEval(ss, s, m).value| == |ss|
+  {
+    if ss == [] then Some([]) else
+    var e :- ss[0].Eval(s, m);
+    var es :- SeqEval(ss[1..], s, m);
+    Some([e] + es)
+  }
+
+  lemma SeqEvalComplete(ss: seq<Expr>, s: State, outs: seq<iset<M.Any>>, m: M.Model)
+    requires RefSeqEval(ss, s, outs, m)
+    ensures SeqExprFVars(ss) <= s.Keys
+    ensures SeqEval(ss, s, m).Some?
+    ensures SeqEval(ss, s, m).value in CrossProduct(outs)
+  {
+    if ss != [] {
+      ss[0].EvalComplete(s, outs[0], m);
+      SeqEvalComplete(ss[1..], s, outs[1..], m);
+      var o :| o in outs[0];
+      var os :| os in CrossProduct(outs[1..]);
+      assert [o] + os in CrossProduct(outs);
+    } else {
+      assert [] in CrossProduct(outs);
+    }
+  }
+
+  lemma SeqEvalSound(ss: seq<Expr>, s: State, funs: set<Function>, outs: seq<iset<M.Any>>, m: M.Model)
+    requires SeqExprFVars(ss) <= s.Keys
+    requires forall func <- funs :: func.IsSound(m)
+    requires forall func <- funs :: func.FunctionsCalled() <= funs
+    requires SeqEval(ss, s, m).Some?
+    requires SeqExprFunctionsCalled(ss) <= funs
+    requires SeqEval(ss, s, m).value in CrossProduct(outs)
+    ensures RefSeqEval(ss, s, outs, m)
+  {
+    if ss != [] {
+      ss[0].EvalSound(s, funs, outs[0], m);
+      SeqEvalSound(ss[1..], s, funs, outs[1..], m);
+      SeqSingletonCons(ss[0].Eval(s, m).value, SeqEval(ss[1..], s, m).value);
+    }
+  }
+
+  lemma SeqEval1(e: Expr, s: State, m: M.Model)
+    requires e.IsDefinedOn(s.Keys)
+    requires e.Eval(s, m).Some?
+    ensures SeqEval([e], s, m) == Some([e.Eval(s, m).value])
+  {
+    calc {
+      SeqEval([e], s, m);
+      == { assert [e][1..] == [];
+           assert [e][0] == e; }
+      Some([e.Eval(s, m).value] + []);
+      == { assert [e.Eval(s, m).value] + [] == [e.Eval(s, m).value]; }
+      Some([e.Eval(s, m).value]);
+    }
+  }
+
+  lemma SeqEval2(e1: Expr, e2: Expr, s: State, m: M.Model)
+    requires e1.IsDefinedOn(s.Keys)
+    requires e2.IsDefinedOn(s.Keys)
+    requires e1.Eval(s, m).Some?
+    requires e2.Eval(s, m).Some?
+    ensures SeqExprFVars([e1, e2]) <= s.Keys
+    ensures SeqEval([e1, e2], s, m) == Some([e1.Eval(s, m).value, e2.Eval(s, m).value])
+  {
+    assert [e1, e2][1..] == [e2];
+    assert [e1, e2][0] == e1;
+    SeqFVarsPairLemma(e1, e2);
+    SeqEval1(e2, s, m); 
+    calc {
+      SeqEval([e1, e2], s, m);
+      == { assert [e1, e2][1..] == [e2];
+            assert [e1, e2][0] == e1;
+            SeqEval1(e2, s, m); }
+      Some([e1.Eval(s, m).value] + SeqEval([e2], s, m).value);
+      == { SeqEval1(e2, s, m);
+            assert [e1.Eval(s, m).value] + [e2.Eval(s, m).value] == [e1.Eval(s, m).value, e2.Eval(s, m).value]; }
+      Some([e1.Eval(s, m).value, e2.Eval(s, m).value]);
+    }
+  }
+
+  lemma SeqEvalFVarsLemma(ss: seq<Expr>, s1: State, s2: State, m: M.Model)
+    requires SeqExprFVars(ss) <= s1.Keys
+    requires SeqExprFVars(ss) <= s2.Keys
+    requires forall v: Variable :: v in SeqExprFVars(ss) ==> s1[v] == s2[v]
+    ensures SeqEval(ss, s1, m) == SeqEval(ss, s2, m)
+  {
+    if ss != [] {
+      ss[0].EvalFVarsLemma(s1, s2, m);
+      SeqEvalFVarsLemma(ss[1..], s1, s2, m);
+    }
+  }
+  
+  function SeqExprFVars(ss: seq<Expr>): set<Variable>
+  {
+    if ss == [] then {} else ss[0].FVars() + SeqExprFVars(ss[1..])
+  }
+
+  function And(e0: Expr, e1: Expr): Expr {
+    OperatorExpr(LogicalAnd, [e0, e1])
+  }
+
+  function Implies(e0: Expr, e1: Expr): Expr {
+    OperatorExpr(LogicalImp, [e0, e1])
+  }
+
+  function Eq(e1: Expr, e2: Expr): Expr {
+    OperatorExpr(Eql, [e1, e2])
+  }
+
+  lemma SeqFVarsPairLemma(e1: Expr, e2: Expr)
+    ensures SeqExprFVars([e1, e2]) == e1.FVars() + e2.FVars()
+  {
+    calc {
+      SeqExprFVars([e1, e2]);
+      ==
+      e1.FVars() + SeqExprFVars([e2]);
+      ==
+      e1.FVars() + e2.FVars() + {};
+    }
+  }
+
+  lemma EvalEqLemma(e1: Expr, e2: Expr, s: State, m: M.Model)
+    requires e1.IsDefinedOn(s.Keys)
+    requires e2.IsDefinedOn(s.Keys)
+    requires e1.Eval(s, m) == e2.Eval(s, m)
+    requires e1.Eval(s, m).Some?
+    ensures Eq(e1, e2).IsDefinedOn(s.Keys)
+    ensures Eq(e1, e2).IsDefinedOn(s.Keys)
+    ensures Eq(e1, e2).HoldsOn(s, m)
+  { 
+    SeqFVarsPairLemma(e1, e2);
+    calc {
+      Eq(e1, e2).Eval(s, m);
+      ==
+      OperatorExpr(Eql, [e1, e2]).Eval(s, m);
+      == { SeqEval2(e1, e2, s, m); }
+      Eql.Eval([e1.Eval(s, m).value, e2.Eval(s, m).value], m);
+      == { EqlEvalLemma(e1.Eval(s, m).value, e2.Eval(s, m).value, m); }
+      Some(m.InterpBool(e1.Eval(s, m).value == e2.Eval(s, m).value));
+      == { assert e1.Eval(s, m) == e2.Eval(s, m); }
+      Some(m.InterpBool(true));
+    }
+  }
+
+  lemma SeqExprFVarsLemma(ss: seq<Expr>, s: Expr) 
+    requires s in ss
+    ensures s.FVars() <= SeqExprFVars(ss)
+  {  }
+
+  lemma SeqExprFVarsLemma'(ss: seq<Expr>, d: set<Variable>) 
+    requires forall e <- ss :: e.FVars() <= d
+    ensures SeqExprFVars(ss) <= d
+  {
+    if ss != [] {
+      assert SeqExprFVars(ss) == ss[0].FVars() + SeqExprFVars(ss[1..]);
+      assert ss[0].FVars() <= d;
+      assert SeqExprFVars(ss[1..]) <= d;
+    }
+  }
+
+  lemma IsDefinedOnAndLemma(e0: Expr, e1: Expr, s: State)
+    requires e0.IsDefinedOn(s.Keys) 
+    requires e1.IsDefinedOn(s.Keys)
+    ensures And(e0, e1).IsDefinedOn(s.Keys) 
+  { 
+    SeqFVarsPairLemma(e0, e1);
+  }
+
+  lemma HoldsOnAndLemma(e0: Expr, e1: Expr, s: State, m: M.Model)
+    requires e0.IsDefinedOn(s.Keys)
+    requires e1.IsDefinedOn(s.Keys)
+    requires e0.HoldsOn(s, m)
+    requires e1.HoldsOn(s, m)
+    ensures And(e0, e1).IsDefinedOn(s.Keys) 
+    ensures And(e0, e1).HoldsOn(s, m)
+  {
+    SeqFVarsPairLemma(e0, e1);
+    SeqEval2(e0, e1, s, m);
+    AndEvalLemma(e0.Eval(s, m).value, e1.Eval(s, m).value, m);
+  }
+
+  lemma HoldsOnImpliesLemma(e0: Expr, e1: Expr, s: State, m: M.Model)
+    requires e0.IsDefinedOn(s.Keys)
+    requires e1.IsDefinedOn(s.Keys)
+    requires e0.HoldsOn(s, m)
+    requires (
+      IsDefinedOnImpliesLemma(e0, e1, s);
+      Implies(e0, e1).HoldsOn(s, m))
+    ensures e1.HoldsOn(s, m)
+  {
+    IsDefinedOnImpliesLemma(e0, e1, s);
+    assert e0.Eval(s, m).Some?;
+    assert SeqEval([e0, e1], s, m).Some?;
+    if e1.Eval(s, m).Some? {
+      SeqEval2(e0, e1, s, m);
+      calc {
+        Implies(e0, e1).Eval(s, m).value;
+        == { SeqEval2(e0, e1, s, m);
+             ImpliesEvalLemma(e0.Eval(s, m).value, e1.Eval(s, m).value, m); }
+        m.Implies(e0.Eval(s, m).value, e1.Eval(s, m).value);
+        ==
+        m.Implies(m.True(), e1.Eval(s, m).value);
+        == { }
+        m.InterpBool(true ==> m.ToBool(e1.Eval(s, m).value));
+        == { }
+        m.InterpBool(m.ToBool(e1.Eval(s, m).value));
+      }
+    }
+  }
+
+  lemma IsDefinedOnImpliesLemma(e0: Expr, e1: Expr, s: State)
+    requires e0.IsDefinedOn(s.Keys)
+    requires e1.IsDefinedOn(s.Keys)
+    ensures Implies(e0, e1).IsDefinedOn(s.Keys)
+  { 
+    SeqFVarsPairLemma(e0, e1);
+  }
+
+  function Conj(ctx: seq<Expr>): Expr 
+  {
+    if ctx == [] then BConst(true) else And(ctx[0], Conj(ctx[1..]))
+  }
+
+  lemma FVarsConjUnionLemma(ctx1: seq<Expr>, ctx2: seq<Expr>)
+    ensures Conj(ctx1 + ctx2).FVars() == Conj(ctx1).FVars() + Conj(ctx2).FVars()
+  {
+    if ctx1 == [] {
+      assert [] + ctx2 == ctx2;
+    } else {
+      assert ctx1 + ctx2 == [ctx1[0]] + (ctx1[1..] + ctx2);
+      calc {
+        Conj(ctx1 + ctx2).FVars();
+        ==
+        And(ctx1[0], Conj(ctx1[1..] + ctx2)).FVars();
+        == { SeqFVarsPairLemma(ctx1[0], Conj(ctx1[1..] + ctx2)); }
+        ctx1[0].FVars() + Conj(ctx1[1..] + ctx2).FVars();
+        == { SeqFVarsPairLemma(ctx1[0], Conj(ctx1[1..])); }
+        Conj(ctx1).FVars() + Conj(ctx2).FVars();
+      }
+    }
+  }
+
+  lemma EvalConjLemma(ctx: seq<Expr>, s: State, m: M.Model)
+    requires forall e <- ctx :: e.IsDefinedOn(s.Keys)
+    requires forall e <- ctx :: e.HoldsOn(s, m)
+    ensures Conj(ctx).IsDefinedOn(s.Keys)
+    ensures Conj(ctx).HoldsOn(s, m)
+  {  
+    if ctx != [] { 
+      IsDefinedOnAndLemma(ctx[0], Conj(ctx[1..]), s); 
+      HoldsOnAndLemma(ctx[0], Conj(ctx[1..]), s, m);
+    }  
+  }
+
+}

--- a/src/Sound/Data/Ast/Stmt.dfy
+++ b/src/Sound/Data/Ast/Stmt.dfy
@@ -1,0 +1,721 @@
+module AST {
+  import opened Std.Wrappers
+  import opened Utils
+  import M = Model
+  import opened State
+  import opened Expr
+
+  datatype ParameterMode = In | InOut | Out
+
+  datatype Parameter = Parameter(v: Variable, mode: ParameterMode)
+  
+  datatype CallArgument = CallArgument(v: Variable, mode: ParameterMode)
+  {
+    function OutArg(): set<Variable> {
+      match this.mode
+      case In => {}
+      case InOut => {this.v}
+      case Out => {this.v}
+    }
+
+    function IsInOutArg(): bool {
+      match this.mode
+      case InOut => true
+      case _ => false
+    }
+
+    predicate IsDefinedOn(d: set<Variable>) {
+      {this.v} <= d
+    }
+
+    function Eval(s: State): M.Any
+      requires IsDefinedOn(s.Keys)
+    {
+      match mode
+      case In => s[v]
+      case InOut => s[v]
+      case Out => s[v]
+    }
+  }
+
+  newtype CallArguments = seq<CallArgument> {
+
+    function OutArgs(): set<Variable> {
+      if this == [] then {} else this[0].OutArg() + this[1..].OutArgs()
+    }
+
+    function NumInOutArgs(): nat {
+      if this == [] then 
+        0 
+      else 
+        if this[0].mode == InOut then 
+          1 + this[1..].NumInOutArgs() 
+        else this[1..].NumInOutArgs()
+    }
+
+
+    function InOutArgs(): seq<Variable> 
+      ensures |InOutArgs()| == NumInOutArgs()
+    {
+      if this == [] then 
+        [] else 
+      if this[0].IsInOutArg() then 
+        [this[0].v] + this[1..].InOutArgs() 
+      else this[1..].InOutArgs()
+    }
+
+    lemma InOutArgsLemma(v: Variable)
+      requires v in InOutArgs()
+      ensures CallArgument(v, InOut) in this
+    {
+
+    }
+
+    lemma OutArgsDepthLemma()
+      ensures OutArgs() <= FVars()
+    { }
+
+    function FVars(): set<Variable> {
+      if this == [] then {} else {this[0].v} + this[1..].FVars()
+    }
+
+    predicate IsDefinedOn(d: set<Variable>) {
+      FVars() <= d
+    }
+
+    lemma IsDefinedOnIn(arg: CallArgument, d: set<Variable>)
+      requires arg in this
+      requires IsDefinedOn(d)
+      ensures arg.IsDefinedOn(d)
+    { 
+      if this != [] {
+        if arg != this[0] {
+          this[1..].IsDefinedOnIn(arg, d);
+        }
+      }
+    }
+      
+    function Eval(s: State): State 
+      requires IsDefinedOn(s.Keys)
+      ensures Eval(s).Keys == FVars()
+    {
+      map v | v in FVars() :: s[v]
+    }
+
+//     function EvalOld(s: State): State 
+//       requires IsDefinedOn(|s|)
+//       ensures |EvalOld(s)| == NumInOutArgs()
+//     {
+//       seq(NumInOutArgs(), (i: nat) requires i < NumInOutArgs() => 
+//         InOutArgsLemma(InOutArgs()[i]);
+//         IsDefinedOnIn(InOutArgument(InOutArgs()[i]), |s|);
+//         s[InOutArgs()[i]]
+//       )
+//     }
+
+//     lemma NumInOutArgsConcatLemma(args: CallArguments)
+//       ensures (this + args).NumInOutArgs() == NumInOutArgs() + args.NumInOutArgs()
+//       ensures (this + args).Depth() == max(this.Depth(), args.Depth())
+//     {
+//       if this == [] {
+//         assert this + args == args;
+//       } else {
+//         assert (this + args)[0] == this[0];
+//         assert (this + args)[1..] == this[1..] + args;
+//         this[1..].NumInOutArgsConcatLemma(args);
+//       }
+//     }
+  }
+
+  class Procedure {
+    const Name: string
+    const Parameters: seq<Parameter>
+    const Pre: seq<Expr>
+    const Post: seq<Expr>
+    var Body: Option<Stmt>
+
+    function ParametersKeys(): set<Variable> {
+      SetOfSeq(seq(|Parameters|, (i: nat) requires i < |Parameters| => Parameters[i].v))
+    }
+
+    function NumInOutArgs'(Parameters: seq<Parameter>): nat {
+      if Parameters == [] then 0 else
+      if Parameters[0].mode == InOut then 1 + NumInOutArgs'(Parameters[1..]) else
+      NumInOutArgs'(Parameters[1..])
+    }
+
+    function NumInOutArgs(): nat {
+      NumInOutArgs'(Parameters)
+    }
+
+//     predicate IsOldVar(i: Idx) 
+//     {
+//       |Parameters| <= i
+//     }
+
+//     function OldVars(): set<Idx> {
+//       set i: Idx | IsOldVar(i) && i < |Parameters| + NumInOutArgs()
+//     }
+
+
+    ghost predicate InPreSet(st: State, m: M.Model) 
+    {
+      && ParametersKeys() /*+ NumInOutArgs()*/ == st.Keys
+      /*&& (forall i: nat :: i < NumInOutArgs() ==> 
+        (InOutVarsIdxsLemma(Parameters, 0, i);
+         st[i + |Parameters|] == st[InOutVarsIdxs()[i]]))*/
+      && forall e <- Pre :: e.IsDefinedOn(st.Keys) && e.HoldsOn(st, m)
+    }
+
+    ghost function PreSet(m: M.Model): iset<State> 
+    {
+      iset st: State | InPreSet(st, m)
+    }
+
+    ghost predicate InPostSet(st: State, m: M.Model) 
+    {
+      forall e <- Post :: e.IsDefinedOn(st.Keys) && e.HoldsOn(st, m)
+    }
+
+    ghost function PostSet(m: M.Model): iset<State> 
+    {
+      iset st': State | InPostSet(st', m)
+    }
+
+    function PostCheck'(p: seq<Expr>): seq<Stmt> 
+      requires forall e <- p :: e.IsDefinedOn(ParametersKeys() /*+ NumInOutArgs()*/)
+      ensures SeqValidCalls(PostCheck'(p))
+      ensures SeqIsDefinedOn(PostCheck'(p), ParametersKeys() /*+ NumInOutArgs()*/)
+      ensures SeqJumpsDefinedOn(PostCheck'(p), 0)
+      ensures SeqVariablesDistinct(PostCheck'(p), ParametersKeys() /*+ NumInOutArgs()*/)
+    {
+      if p == [] then [] else
+        assert forall e <- p[1..] :: e in p;
+        assert p[0] in p;
+        assert p[0].IsDefinedOn(ParametersKeys() /*+ NumInOutArgs()*/);
+        assert Check(p[0]).IsDefinedOn(ParametersKeys() /*+ NumInOutArgs()*/);
+        [Check(p[0])] + PostCheck'(p[1..])
+    }
+
+    function PostCheck(): seq<Stmt> 
+      requires Valid()
+      ensures SeqValidCalls(PostCheck())
+      ensures SeqIsDefinedOn(PostCheck(), ParametersKeys() /*+ NumInOutArgs()*/)
+      ensures SeqVariablesDistinct(PostCheck(), ParametersKeys() /*+ NumInOutArgs()*/)
+      reads this`Body
+    {
+      PostCheck'(Post)
+    }
+
+//     function InOutVarsIdxs'(parameter: seq<Parameter>, idx: Idx): seq<Idx>
+//       ensures |InOutVarsIdxs'(parameter, idx)| == NumInOutArgs'(parameter)
+//     {
+//       if parameter == [] then [] else
+//       if parameter[0].mode == InOut then
+//         [idx] + InOutVarsIdxs'(parameter[1..], idx + 1)
+//       else
+//         InOutVarsIdxs'(parameter[1..], idx + 1)
+//     }
+
+//     function InOutVarsIdxs(): seq<Idx>
+//     {
+//       InOutVarsIdxs'(Parameters, 0)
+//     }
+
+//     lemma InOutVarsIdxsLemma(parameter: seq<Parameter>, idx: Idx, i: nat)
+//       requires i < |InOutVarsIdxs'(parameter, idx)|
+//       ensures InOutVarsIdxs'(parameter, idx)[i] < |parameter| + idx
+//     {
+//       if parameter != [] {
+//         if i != 0 {
+//           InOutVarsIdxsLemma(parameter[1..], idx + 1, i - 1);
+//         }
+//       }
+//     }
+
+//     function InOutArgsState(st: State): State
+//       requires |Parameters| <= |st|
+//     {
+//       seq(|InOutVarsIdxs()|, (i: nat) requires i < |InOutVarsIdxs()| => 
+//         InOutVarsIdxsLemma(Parameters, 0, i);
+//         st[InOutVarsIdxs()[i]])
+//     }
+
+    ghost predicate ValidBody() 
+      requires Body.Some?
+      reads this`Body
+    {
+      var body := Body.value;
+      && body.ValidCalls()
+      && body.IsDefinedOn(ParametersKeys() /*+ NumInOutArgs()*/)
+      && body.JumpsDefinedOn(0)
+      && body.VariablesDistinct(ParametersKeys() /*+ NumInOutArgs()*/)
+      // && body.ImmutableVars(OldVars())
+    }
+
+    ghost predicate Valid() 
+      reads this`Body
+    {
+      && (Body.Some? ==> ValidBody())
+      && (forall e <- Pre :: e.IsDefinedOn(ParametersKeys() /*+ NumInOutArgs()*/))
+      && (forall e <- Post :: e.IsDefinedOn(ParametersKeys() /*+ NumInOutArgs()*/))
+    }
+
+    function ProceduresCalled(): set<Procedure> 
+      reads this`Body
+    {
+      if Body.Some? then Body.value.ProceduresCalled() else {}
+    }
+
+    function FunctionsCalled(): set<Function> 
+      reads this`Body
+    {
+      if Body.Some? then Body.value.FunctionsCalled() + SeqExprFunctionsCalled(Pre) + SeqExprFunctionsCalled(Post) else {}
+    }
+
+    ghost predicate IsSafe(m: M.Model) 
+      reads this`Body
+    {
+      && (forall e <- Pre :: e.IsSafe(m))
+      && (forall e <- Post :: e.IsSafe(m))
+      && (Body.Some? ==> Body.value.IsSafe(m))
+    }
+
+    lemma IsSafeLemma'(p: seq<Expr>, m: M.Model)
+      requires forall e <- p :: e.IsSafe(m)
+      requires forall e <- p :: e.IsDefinedOn(ParametersKeys() /*+ NumInOutArgs()*/)
+      ensures SeqIsSafe(PostCheck'(p), m)
+    {
+      if p != [] {
+        assert p[0] in p;
+        IsSafeLemma'(p[1..], m) by {
+          assert forall e <- p[1..] :: e in p;
+        }
+      }
+    }
+
+    lemma IsSafeLemma(m: M.Model)
+      requires IsSafe(m)
+      requires Valid()
+      ensures SeqIsSafe(PostCheck(), m)
+    {
+      IsSafeLemma'(Post, m);
+    }
+
+    ghost predicate IsSafeWith(funs: set<Function>)
+      reads *
+    {
+      forall md: M.Model ::
+        (forall func <- funs :: func.IsSound(md)) ==> IsSafe(md)
+    }
+
+    lemma IsSafePostCheckLemma'(m: M.Model, p: seq<Expr>)
+      requires forall e <- p :: e.IsSafe(m)
+      requires forall e <- p :: e.IsDefinedOn(ParametersKeys() /*+ NumInOutArgs()*/)
+      ensures SeqIsSafe(PostCheck'(p), m)
+    {
+      if p != [] {
+        assert p[0] in p;
+        IsSafePostCheckLemma'(m, p[1..]);
+      }
+    }
+
+    lemma IsSafePostCheckLemma(m: M.Model)
+      requires IsSafe(m)
+      requires Valid()
+      ensures SeqIsSafe(PostCheck(), m)
+    {
+      IsSafePostCheckLemma'(m, Post);
+    }
+  }
+
+  ghost predicate SeqSafeWith(procs: seq<Procedure>, funs: set<Function>)
+    reads *
+  {
+    forall proc <- procs :: proc.IsSafeWith(funs)
+  }
+
+  datatype Stmt =
+    | Check(e: Expr)
+    | Assume(e: Expr)
+    | Seq(ss: seq<Stmt>)
+    | Assign(lhs: Variable, rhs: Expr)
+    | NewScope(vars: set<Variable>, s: Stmt)
+    | Escape(l: nat)
+    | Choice(0: Stmt, 1: Stmt)
+    | Loop(inv: Expr, body: Stmt)
+    | Call(proc: Procedure, args: CallArguments)
+  {
+
+    predicate Single() {
+      match this
+      case Assign(_, _) => true
+      case Check(_) => true
+      case Assume(_) => true
+      case Call(_, _) => true
+      case _ => false
+    }
+
+    ghost predicate VariablesDistinct(vars: set<Variable>)
+    {
+      match this
+      case Seq(ss) => SeqVariablesDistinct(ss, vars)
+      case Choice(s0, s1) => s0.VariablesDistinct(vars) && s1.VariablesDistinct(vars)
+      case NewScope(vs, s) => vs !! vars && s.VariablesDistinct(vars + vs)
+      case Loop(inv, body) => body.VariablesDistinct(vars)
+      case _ => true
+    }
+
+    predicate ValidCalls() {
+      match this
+      case Call(proc, args) =>
+        && SeqExprFVars(proc.Pre) <= args.FVars()
+        && SeqExprFVars(proc.Post) <= args.FVars() /*+ args.NumInOutArgs()*/
+      case Seq(ss) => forall s <- ss :: s.ValidCalls()
+      case Choice(s0, s1) => s0.ValidCalls() && s1.ValidCalls()
+      case NewScope(n, s) => s.ValidCalls()
+      case Loop(inv, body) => body.ValidCalls()
+      case _ =>
+        true
+    }
+
+    function Size(): nat {
+      match this
+      case Check(_) => 1
+      case Assume(_) => 1
+      case Seq(ss) => 1 + SeqSize(ss)
+      case Assign(_, _) => 1
+      case Choice(s0, s1) => 1 + s0.Size() + s1.Size()
+      case NewScope(n, s) => 2 + s.Size()
+      case Escape(l) => 2
+      case Loop(inv, body) => 4 + body.Size()
+      case Call(proc, args) => 1
+    }
+
+    function FVars(): set<Variable> {
+      match this
+      case Check(e) => e.FVars()
+      case Assume(e) => e.FVars()
+      case Seq(ss) => SeqFVars(ss)
+      case Assign(x, rhs) => {x} + rhs.FVars()
+      case Choice(s0, s1) => s0.FVars() + s1.FVars()
+      case NewScope(vars, s) => vars + s.FVars()
+      case Escape(l) => {}
+      case Loop(inv, body) => inv.FVars() + body.FVars()
+      case Call(proc, args) => args.FVars() /*+ args.NumInOutArgs()*/
+    }
+
+    function BVars(): set<Variable> {
+      match this
+      case Choice(s0, s1) => s0.BVars() + s1.BVars()
+      case NewScope(vars, s) => vars + s.BVars()
+      case Loop(inv, body) => body.BVars()
+      case Seq(ss) => SeqBVars(ss)
+      case _ => {}
+    }
+
+    predicate IsDefinedOn(vars: set<Variable>) 
+    {
+      FVars() <= vars
+    }
+
+
+    function JumpDepth() : nat {
+      match this
+      case Check(e) => 0
+      case Assume(e) => 0
+      case Assign(id, rhs) => 0
+      case Seq(ss) => SeqJumpDepth(ss)
+      case Choice(s0, s1) => max(s0.JumpDepth(), s1.JumpDepth())
+      case NewScope(n, s) => if s.JumpDepth() == 0 then 0 else s.JumpDepth() - 1
+      case Escape(l) => l
+      case Loop(inv, body) => body.JumpDepth()
+      case Call(proc, args) => 0
+    }
+
+    predicate JumpsDefinedOn(d: nat) {
+      JumpDepth() <= d
+    }
+
+    function ProceduresCalled(): set<Procedure> {
+      match this
+      case Call(proc, _) => {proc}
+      case Seq(ss) => SeqProceduresCalled(ss)
+      case Choice(s0, s1) => s0.ProceduresCalled() + s1.ProceduresCalled()
+      case NewScope(_, s) => s.ProceduresCalled()
+      case Loop(_, body) => body.ProceduresCalled()
+      case _ => {}
+    }
+
+    function FunctionsCalled(): set<Function> {
+      match this
+      case Seq(ss) => SeqFunctionsCalled(ss)
+      case Choice(s0, s1) => s0.FunctionsCalled() + s1.FunctionsCalled()
+      case NewScope(_, s) => s.FunctionsCalled()
+      case Loop(_, body) => body.FunctionsCalled() + inv.FunctionsCalled()
+      case Check(e) => e.FunctionsCalled()
+      case Assume(e) => e.FunctionsCalled()
+      case Assign(_, rhs) => rhs.FunctionsCalled()
+      case Call(proc, args) => SeqExprFunctionsCalled(proc.Pre) + SeqExprFunctionsCalled(proc.Post)
+      case Escape(l) => {}
+    }
+
+    lemma VariablesDistinctBVars(vs: set<Variable>)
+      requires VariablesDistinct(vs)
+      ensures vs !! BVars()
+    {
+      match this
+      case Seq(ss) => 
+        DistinctSeqBVars(ss, vs) by {
+          forall s | s in ss { s.VariablesDistinctBVars(vs); }
+        }
+      case _ => 
+    }
+
+    lemma VariablesDistinctUnion(vars1: set<Variable>, vars2: set<Variable>)
+      requires VariablesDistinct(vars1)
+      requires vars2 !! BVars()
+      ensures VariablesDistinct(vars1 + vars2)
+    {
+      match this
+      case Seq(ss) => SeqVariablesDistinctUnion(ss, vars1, vars2);
+      case NewScope(vars, s) => 
+        s.VariablesDistinctBVars(vars1 + vars);
+        s.VariablesDistinctUnion(vars1 + vars, vars2);
+        assert vars1 + vars + vars2 == vars1 + vars2 + vars;
+      case _ => 
+    }
+
+//     predicate ImmutableVarsIdx(vars: set<Idx>, i: Idx) {
+//       match this
+//       case Assign(x, _) => x + i !in vars
+//       case NewScope(n, s) => s.ImmutableVarsIdx(vars, i + n) 
+//       case Seq(ss) => SeqImmutableVarsIdx(ss, vars, i)
+//       case Choice(s0, s1) => s0.ImmutableVarsIdx(vars, i) && s1.ImmutableVarsIdx(vars, i)
+//       case Loop(_, body) => body.ImmutableVarsIdx(vars, i)
+//       case _ => true
+//     }
+
+//     predicate ImmutableVars(vars: set<Idx>) {
+//       ImmutableVarsIdx(vars, 0)
+//     }
+
+    lemma IsDefinedOnTransitivity(d1: set<Variable>, d2: set<Variable>)
+      requires d1 <= d2
+      ensures IsDefinedOn(d1) ==> IsDefinedOn(d2)
+    {  }
+
+    ghost predicate IsSafe(m: M.Model) {
+      match this
+      case Check(e) => e.IsSafe(m)
+      case Assume(e) => e.IsSafe(m)
+      case Assign(_, e) => e.IsSafe(m)
+      case Seq(ss) => SeqIsSafe(ss, m)
+      case Choice(s0, s1) => s0.IsSafe(m) && s1.IsSafe(m)
+      case NewScope(_, s) => s.IsSafe(m)
+      case Escape(l) => true
+      case Loop(inv, body) => inv.IsSafe(m) && body.IsSafe(m)
+      case Call(proc, args) => true
+    }
+  }
+
+  ghost predicate SeqIsSafe(ss: seq<Stmt>, m: M.Model) {
+    forall s <- ss :: s.IsSafe(m)
+  }
+
+  lemma SeqIsSafeSeq(ss: seq<Stmt>, cont: seq<Stmt>, m: M.Model)
+    requires SeqIsSafe([Seq(ss)] + cont, m)
+    ensures SeqIsSafe(ss, m)
+  {
+    assert Seq(ss) in [Seq(ss)] + cont;
+  }
+
+  lemma ChoiceIsSafe(s1: Stmt, s2: Stmt, cont: seq<Stmt>, m: M.Model)
+    requires SeqIsSafe([Choice(s1, s2)] + cont, m)
+    ensures SeqIsSafe([s1] + cont, m)
+    ensures SeqIsSafe([s2] + cont, m)
+  {
+    assert Choice(s1, s2) in [Choice(s1, s2)] + cont;
+    assert Choice(s1, s2).IsSafe(m);
+  }
+
+  lemma NewScopeIsSafe(vars: set<Variable>, s: Stmt, cont: seq<Stmt>, m: M.Model)
+    requires SeqIsSafe([NewScope(vars, s)] + cont, m)
+    ensures SeqIsSafe([s], m)
+  {
+    assert NewScope(vars, s) in [NewScope(vars, s)] + cont;
+    assert NewScope(vars, s).IsSafe(m);
+  }
+
+  lemma LoopIsSafe(inv: Expr, body: Stmt, cont: seq<Stmt>, m: M.Model)
+    requires SeqIsSafe([Loop(inv, body)] + cont, m)
+    ensures SeqIsSafe([Assume(inv), body, Check(inv), Assume(BConst(false))], m)
+  {
+    assert Loop(inv, body) in [Loop(inv, body)] + cont;
+    assert Loop(inv, body).IsSafe(m);
+  }
+
+  ghost predicate SeqVariablesDistinct(ss: seq<Stmt>, vars: set<Variable>)
+  {
+    forall s <- ss :: s.VariablesDistinct(vars)
+  }
+
+  lemma SeqVariablesDistinctSeq(ss: seq<Stmt>, cont: seq<Stmt>, vars: set<Variable>)
+    requires SeqVariablesDistinct([Seq(ss)] + cont, vars)
+    ensures SeqVariablesDistinct(ss + cont, vars)
+  {
+    forall s | s in ss + cont ensures s.VariablesDistinct(vars) {
+      if s in cont {
+        assert s in [Seq(ss)] + cont;
+      } else {
+        assert Seq(ss) in [Seq(ss)] + cont;
+        assert SeqVariablesDistinct(ss, vars);
+      }
+    }
+  }
+
+  lemma SeqVariablesDistinctChoice(s1: Stmt, s2: Stmt, cont: seq<Stmt>, vars: set<Variable>)
+    requires SeqVariablesDistinct([Choice(s1, s2)] + cont, vars)
+    ensures SeqVariablesDistinct([s1] + cont, vars)
+    ensures SeqVariablesDistinct([s2] + cont, vars)
+  {
+    forall s | s in [s1] + [s2] + cont ensures s.VariablesDistinct(vars) {
+      if s in cont {
+        assert s in [Choice(s1, s2)] + cont;
+      } else if s == s1 || s == s2 {
+        assert Choice(s1, s2) in [Choice(s1, s2)] + cont;
+        assert Choice(s1, s2).VariablesDistinct(vars);
+      }
+    }
+  }
+
+
+
+  lemma SeqVariablesDistinctNewScope(s: Stmt, vars: set<Variable>, cont: seq<Stmt>, vs: set<Variable>)
+    requires SeqVariablesDistinct([NewScope(vars, s)] + cont, vs)
+    ensures SeqVariablesDistinct([s], vs + vars)
+    ensures vs + vars !! SeqBVars([s])
+  {
+    assert NewScope(vars, s) in [NewScope(vars, s)] + cont;
+    assert NewScope(vars, s).VariablesDistinct(vs);
+    s.VariablesDistinctBVars(vs + vars);
+  }
+
+  lemma SeqVariablesDistinctUnion(ss: seq<Stmt>, vars1: set<Variable>, vars2: set<Variable>)
+    requires SeqVariablesDistinct(ss, vars1)
+    requires vars2 !! SeqBVars(ss)
+    ensures SeqVariablesDistinct(ss, vars1 + vars2)
+  {
+    forall s | s in ss ensures s.VariablesDistinct(vars1 + vars2) {
+      DistinctSeqBVars'(ss, vars2, s);
+      s.VariablesDistinctUnion(vars1, vars2);
+    }
+  }
+
+  lemma SeqVariablesDistinctLoop(body: Stmt, inv: Expr, cont: seq<Stmt>, vars: set<Variable>)
+    requires SeqVariablesDistinct([Loop(inv, body)] + cont, vars)
+    ensures SeqVariablesDistinct([Assume(inv), body, Check(inv), Assume(BConst(false))], vars)
+  {
+    assert body.VariablesDistinct(vars) by {
+      assert Loop(inv, body) in [Loop(inv, body)] + cont;
+      assert Loop(inv, body).VariablesDistinct(vars);
+    }
+  }
+
+  predicate SeqValidCalls(ss: seq<Stmt>) {
+    forall s <- ss :: s.ValidCalls()
+  }
+
+  function SeqProceduresCalled(ss: seq<Stmt>): set<Procedure> {
+    if ss == [] then {} else ss[0].ProceduresCalled() + SeqProceduresCalled(ss[1..])
+  }
+
+  function SeqFunctionsCalled(ss: seq<Stmt>): set<Function> {
+    if ss == [] then {} else ss[0].FunctionsCalled() + SeqFunctionsCalled(ss[1..])
+  }
+
+  lemma SeqProceduresCalledLemma(ss: seq<Stmt>, s: Stmt, proc: Procedure)
+    requires s in ss
+    requires proc in s.ProceduresCalled()
+    ensures proc in SeqProceduresCalled(ss)
+  {
+
+  }
+
+//   predicate SeqImmutableVarsIdx(ss: seq<Stmt>, vars: set<Idx>, i: Idx)
+//   {
+//     if ss == [] then true else
+//     ss[0].ImmutableVarsIdx(vars, i) && SeqImmutableVarsIdx(ss[1..], vars, i)
+//   }
+
+  function SeqSize(ss: seq<Stmt>): nat {
+    if ss == [] then 0 else ss[0].Size() + SeqSize(ss[1..])
+  }
+
+  lemma SeqSizeSplitLemma(ss: seq<Stmt>)
+    requires ss != []
+    ensures SeqSize(ss) == ss[0].Size() + SeqSize(ss[1..])
+  {  }
+
+  function SeqFVars(ss: seq<Stmt>): set<Variable> 
+  {
+    if ss == [] then {} else ss[0].FVars() + SeqFVars(ss[1..])
+  }
+
+  function SeqBVars(ss: seq<Stmt>): set<Variable> {
+    if ss == [] then {} else ss[0].BVars() + SeqBVars(ss[1..])
+  }
+
+  lemma DistinctSeqBVars(ss: seq<Stmt>, vars: set<Variable>)
+    requires forall s <- ss :: vars !! s.BVars()
+    ensures vars !! SeqBVars(ss)
+  {  }
+
+  lemma DistinctSeqBVars'(ss: seq<Stmt>, vars: set<Variable>, s: Stmt)
+    requires vars !! SeqBVars(ss)
+    requires s in ss
+    ensures vars !! s.BVars()
+  {  }
+
+  predicate SeqIsDefinedOn(ss: seq<Stmt>, d: set<Variable>) 
+    ensures SeqIsDefinedOn(ss, d) <==> SeqFVars(ss) <= d
+  {
+    if ss == [] then true else ss[0].IsDefinedOn(d) && SeqIsDefinedOn(ss[1..], d)
+  }
+
+  lemma SeqIsDefinedOnForall(ss: seq<Stmt>, d: set<Variable>)
+    requires forall s <- ss :: s.IsDefinedOn(d)
+    ensures SeqIsDefinedOn(ss, d)
+  {
+    // if ss != [] {
+    //   assert ss[0].IsDefinedOn(d);
+    //   assert SeqIsDefinedOn(ss[1..], d);
+    // }
+  }
+
+  function SeqJumpDepth(ss: seq<Stmt>): nat {
+    if ss == [] then 0 else max(ss[0].JumpDepth(), SeqJumpDepth(ss[1..]))
+  }
+
+  predicate SeqJumpsDefinedOn(ss: seq<Stmt>, d: nat) 
+    ensures SeqJumpsDefinedOn(ss, d) <==> SeqJumpDepth(ss) <= d
+  {
+    if ss == [] then true else ss[0].JumpsDefinedOn(d) && SeqJumpsDefinedOn(ss[1..], d)
+  }
+
+  lemma SeqFunConcatLemmas(ss1: seq<Stmt>, ss2: seq<Stmt>)
+    ensures SeqSize(ss1 + ss2) == SeqSize(ss1) + SeqSize(ss2)
+    ensures SeqFVars(ss1 + ss2) == SeqFVars(ss1) + SeqFVars(ss2)
+    ensures SeqBVars(ss1 + ss2) == SeqBVars(ss1) + SeqBVars(ss2)
+    ensures SeqJumpDepth(ss1 + ss2) == max(SeqJumpDepth(ss1), SeqJumpDepth(ss2))
+    ensures SeqFunctionsCalled(ss1 + ss2) == SeqFunctionsCalled(ss1) + SeqFunctionsCalled(ss2)
+  {
+    if ss1 == [] {
+      assert ss1 + ss2 == ss2;
+    } else {
+      assert (ss1 + ss2)[0] == ss1[0];
+      assert (ss1 + ss2)[1..] == ss1[1..] + ss2;
+    }
+  }
+
+}

--- a/src/Sound/Data/State/Model.dfy
+++ b/src/Sound/Data/State/Model.dfy
@@ -1,0 +1,286 @@
+module Model {
+  import opened Utils
+  export
+    provides Utils,
+      PreModel, PreModel.InferType, PreModel.Valid,
+      PreModel.InterpLiteral,
+      PreModel.InterpInt, PreModel.InterpBool, PreModel.ToInt, PreModel.ToBool,
+      PreModel.Not, PreModel.Equiv, PreModel.Or, PreModel.Negate, PreModel.Plus, PreModel.Minus, PreModel.Times, PreModel.Div, PreModel.Mod, PreModel.Less, 
+      PreModel.AtMost, PreModel.NoEmptyTypes, PreModel.InterpFunctionOn, PreModel.BoolIsTrueOrFalse, PreModel.TrueNotFalse
+    reveals Any, Model,  Bot, PreModel,
+      PreModel.True, PreModel.False, PreModel.LogicAnd, PreModel.IsBool, PreModel.IsInt, PreModel.HasType, PreModel.Implies, 
+      Literal, FunctionSig, Function, Type, Int, Bool, PreModel.Eql, PreModel.Neql,
+      PreModel.HaveTypes
+
+  type Type = string
+  const Int : Type := "int"
+  const Bool : Type := "bool"
+  datatype Literal = Literal(value: string, typ: Type)
+  type FunctionSig = seq<Type>
+  datatype Function = Function(name: string, sig: FunctionSig, resultType: Type)
+  
+  // TODO: module refinement for Any
+  type Any(!new, ==)
+
+  function {:axiom} Bot(): Any
+
+  function {:axiom} EmbedInt(x: int): Any
+
+  function {:axiom} EmbedBool(x: bool): Any
+
+  /**
+  lemmas about embedding and embedding back
+   */
+
+  datatype PreModel = Model(
+    inferType: Any -> Type,
+    interpLiteral: Literal -> Any,
+    interpInt: int -> Any,
+    interpBool: bool -> Any,
+    toInt: Any --> int,
+    toBool: Any --> bool,
+    interpFunctionOn: (Function, seq<Any>) --> Any
+    ) {
+
+    ghost opaque predicate Valid() {
+      && (forall typ: Type :: exists x: Any :: HasType(x, typ))
+      && (forall x: Literal :: HasType(interpLiteral(x), x.typ))
+      && (forall x: int :: HasType(interpInt(x), Int))
+      && (forall x: bool :: HasType(interpBool(x), Bool))
+      && (forall x: Any :: IsInt(x) ==> toInt.requires(x))
+      && (forall x: Any :: IsBool(x) ==> toBool.requires(x))
+      && (forall x: Any :: IsInt(x) ==> interpInt(toInt(x)) == x)
+      && (forall x: Any :: IsBool(x) ==> interpBool(toBool(x)) == x)
+      && (interpBool(true) != interpBool(false))
+      && (forall func: Function, args: seq<Any> :: HaveTypes(args, func.sig) ==> interpFunctionOn.requires(func, args))
+      && (forall func: Function, args: seq<Any> :: HaveTypes(args, func.sig) ==> HasType(interpFunctionOn(func, args), func.resultType))
+    }
+    function InferType(x: Any): Type
+    {
+      inferType(x)
+    }
+    
+    predicate HasType(x: Any, typ: Type) {
+      InferType(x) == typ
+    }
+
+    lemma NoEmptyTypes(typ: Type) returns (x: Any)
+      requires Valid()
+      ensures HasType(x, typ)
+    {
+      assert (forall typ: Type :: exists x: Any :: HasType(x, typ)) by {
+        reveal Valid;
+      }
+      var x': Any :| HasType(x', typ);
+      x := x';
+    }
+
+    opaque function InterpLiteral(x: Literal): Any
+      requires Valid()
+      ensures HasType(InterpLiteral(x), x.typ)
+    {
+      reveal Valid;
+      interpLiteral(x)
+    }
+
+    predicate IsInt(x: Any) {
+      HasType(x, Int)
+    }
+
+    predicate IsBool(x: Any) {
+      HasType(x, Bool)
+    }
+
+    opaque function InterpInt(x: int): Any
+      requires Valid()
+      ensures HasType(InterpInt(x), Int)
+    {
+      reveal Valid;
+      interpInt(x)
+    }
+
+    opaque function InterpBool(x: bool): Any
+      requires Valid()
+      ensures HasType(InterpBool(x), Bool)
+    {
+      reveal Valid;
+      interpBool(x)
+    }
+
+    opaque function ToBool(x: Any): bool
+      requires Valid()
+      requires IsBool(x)
+      ensures InterpBool(ToBool(x)) == x
+    {
+      reveal Valid;
+      reveal InterpBool;
+      toBool(x)
+    }
+
+    opaque function ToInt(x: Any): int
+      requires Valid()
+      requires IsInt(x)
+      ensures InterpInt(ToInt(x)) == x
+    {
+      reveal Valid;
+      reveal InterpInt;
+      toInt(x)
+    }
+
+    function True(): Any requires Valid() { InterpBool(true) }
+    function False(): Any requires Valid() { InterpBool(false) }
+
+    lemma TrueNotFalse()
+      requires Valid()
+      ensures True() != False()
+    {
+      reveal Valid;
+      reveal InterpBool;
+    }
+
+    function Eql(x: Any, y: Any): Any 
+      requires Valid()
+    {
+      InterpBool(x == y)
+    }
+
+    function Neql(x: Any, y: Any): Any 
+      requires Valid()
+    {
+      InterpBool(x != y)
+    }
+
+    function Not(x: Any): Any
+      requires Valid()
+      requires IsBool(x)
+    {
+      InterpBool(!ToBool(x))
+    }
+
+    function LogicAnd(x: Any, y: Any): Any
+      requires Valid()
+      requires IsBool(x)
+      requires IsBool(y)
+    {
+      InterpBool(ToBool(x) && ToBool(y))
+    }
+
+    function Implies(x: Any, y: Any): Any
+      requires Valid()
+      requires IsBool(x)
+      requires IsBool(y)
+    {
+      InterpBool(ToBool(x) ==> ToBool(y))
+    }
+
+    function Equiv(x: Any, y: Any): Any
+      requires Valid()
+      requires IsBool(x)
+      requires IsBool(y)
+    {
+      InterpBool(ToBool(x) <==> ToBool(y))
+    }
+
+    function Or(x: Any, y: Any): Any
+      requires Valid()
+      requires IsBool(x)
+      requires IsBool(y)
+    {
+      InterpBool(ToBool(x) || ToBool(y))
+    }
+
+    function Negate(x: Any): Any
+      requires Valid()
+      requires IsInt(x)
+    {
+      InterpInt(-ToInt(x))
+    }
+
+    function Plus(x: Any, y: Any): Any
+      requires Valid()
+      requires IsInt(x)
+      requires IsInt(y)
+    {
+      InterpInt(ToInt(x) + ToInt(y))
+    }
+
+    function Minus(x: Any, y: Any): Any
+      requires Valid()
+      requires IsInt(x)
+      requires IsInt(y)
+    {
+      InterpInt(ToInt(x) - ToInt(y))
+    }
+
+    function Times(x: Any, y: Any): Any
+      requires Valid()
+      requires IsInt(x)
+      requires IsInt(y)
+    {
+      InterpInt(ToInt(x) * ToInt(y))
+    }
+
+    function Div(x: Any, y: Any): Any
+      requires Valid()
+      requires IsInt(x)
+      requires IsInt(y)
+      requires ToInt(y) != 0
+    {
+      InterpInt(ToInt(x) / ToInt(y))
+    }
+
+    function Mod(x: Any, y: Any): Any
+      requires Valid()
+      requires IsInt(x)
+      requires IsInt(y)
+      requires ToInt(y) != 0
+    {
+      InterpInt(ToInt(x) % ToInt(y))
+    }
+
+    function Less(x: Any, y: Any): Any
+      requires Valid()
+      requires IsInt(x)
+      requires IsInt(y)
+    {
+      InterpBool(ToInt(x) < ToInt(y))
+    }
+
+    function AtMost(x: Any, y: Any): Any
+      requires Valid()
+      requires IsInt(x)
+      requires IsInt(y)
+    {
+      InterpBool(ToInt(x) <= ToInt(y))
+    }
+
+    predicate HaveTypes(args: seq<Any>, sig: FunctionSig) {
+      |args| == |sig| && forall i :: 0 <= i < |args| ==> HasType(args[i], sig[i])
+    }
+
+    opaque function InterpFunctionOn(func: Function, args: seq<Any>): Any
+      requires Valid()
+      requires HaveTypes(args, func.sig)
+      ensures HasType(InterpFunctionOn(func, args), func.resultType)
+    {
+      reveal Valid;
+      interpFunctionOn(func, args)
+    }
+
+    lemma BoolIsTrueOrFalse(x: Any)
+      requires Valid()
+      requires IsBool(x)
+      ensures x == True() || x == False()
+    {
+      reveal Valid;
+      reveal InterpBool;
+      assert x == InterpBool(ToBool(x));
+    }
+  }
+    
+  
+  type Model = m: PreModel | m.Valid() witness *
+
+  // predicate
+
+}

--- a/src/Sound/Data/State/State.dfy
+++ b/src/Sound/Data/State/State.dfy
@@ -1,0 +1,174 @@
+module State {
+  import opened Utils
+  import opened Std.Wrappers
+  import M = Model
+
+  function SomeBVal?(o: Option<M.Any>, m: M.Model): bool {
+    match o
+    case Some(b) => m.IsBool(b)
+    case _ => false
+  }
+
+  // function SomeBValTrue?(o: Option<M.Any>): bool {
+  //   match o
+  //   case Some(b) => b == True
+  //   case _ => false
+  // }
+
+  datatype Type = 
+    | BType 
+    | IType 
+    | CustomType(typ: M.Type)
+  {
+    function ToType(): M.Type {
+      match this
+      case BType => M.Bool
+      case IType => M.Int
+      case CustomType(typ) => typ
+    }
+  }
+
+  datatype Variable = Variable(name: string, typ: Type) {
+    function FreshVar(vars: set<Variable>): Variable
+      ensures FreshVar(vars) !in vars
+      ensures FreshVar(vars).typ == typ
+    {
+      if vars == {} then this else
+        var m := MaxLenVar(vars);
+        if |name| > |m.name| then this else
+        Variable(name + "$" + m.name, typ)
+    }
+  }
+
+  function MaxLenVar(s: set<Variable>): (m: Variable)
+    requires s != {}
+    ensures m in s && forall z :: z in s ==> |z.name| <= |m.name|
+  // {
+  //   var x :| x in s;
+  //   if s == {x} then
+  //     x
+  //   else
+  //     var s' := s - {x};
+  //     assert s == s' + {x};
+  //     var y := MaxLenVar(s');
+  //     if |x.name| >= |y.name| then x else y
+  // } by method {
+  //   m :| m in s;
+  //   var r := s - {m};
+  //   while r != {}
+  //     invariant r < s
+  //     invariant m in s && forall z :: z in s - r ==> |z.name| <= |m.name|
+  //   {
+  //     var x :| x in r;
+  //     assert forall z :: z in s - (r - {x}) ==> z in s - r || z == x;
+  //     r := r - {x};
+  //     if |m.name| < |x.name| {
+  //       m := x;
+  //     }
+  //   }
+  //   assert s - {} == s;
+  //   assert m in s && forall z :: z in s ==> |z.name| <= |m.name|;
+  // }
+
+  // function Singleton(val: M.Any): State
+  // {
+  //   [val]
+  // }
+
+  // function ToState(args: map<Variable, M.Any>): State
+  // {
+  //   args as State
+  // }
+
+  newtype State = map<Variable, M.Any> {
+
+    function Update(vals: map<Variable, M.Any>): State 
+    {
+      ((vals + (this as map<Variable, M.Any>)) as State)
+    }
+
+    function Size(): nat {
+      |this|
+    }
+
+    function UpdateAt(v: Variable, val: M.Any): State
+    {
+      this[v := val]
+    }
+
+    function Restrict(vars: set<Variable>): State
+      ensures Restrict(vars).Keys == this.Keys * vars
+    {
+      map v | v in this.Keys && v in vars :: this[v]
+    }
+
+    function Without(vars: set<Variable>): State
+      ensures Without(vars).Keys == this.Keys - vars
+    {
+      map v | v in this.Keys && v !in vars :: this[v]
+    }
+
+    // function UpdateMapShift(i: Idx, vals: map<Idx, M.Any>): State  
+    //   ensures |UpdateMapShift(i, vals)| > i
+    //   ensures |UpdateMapShift(i, vals)| >= |this|
+    //   ensures forall v <- vals.Keys :: |UpdateMapShift(i, vals)| > v + i
+    //   ensures |UpdateMapShift(i, vals)| > Max'(vals.Keys) + i
+    //   ensures forall j: Idx :: j < |this| && (j < i || j - i !in vals.Keys) ==> UpdateMapShift(i, vals)[j] == this[j]
+    //   ensures forall j: Idx :: j in vals.Keys ==> UpdateMapShift(i, vals)[j + i] == vals[j]
+    // {
+    //   var m := Max'(vals.Keys);
+    //   seq(max(i + m + 1, |this|), (j: nat) requires j < max(i + m + 1, |this|) => 
+    //     if j - i in vals.Keys then 
+    //       vals[j - i] 
+    //     else if j < |this| then
+    //       this[j]
+    //     else Bot()
+    //   )
+    // }
+
+    // function UpdateOrAdd(i: Idx, val: M.Any): State 
+    //   ensures |UpdateOrAdd(i, val)| > i
+    //   ensures |UpdateOrAdd(i, val)| >= |this|
+    //   ensures forall j: Idx :: j < |this| ==> j != i ==> UpdateOrAdd(i, val)[j] == this[j]
+    //   ensures UpdateOrAdd(i, val)[i] == val
+    // {
+    //   UpdateMapShift(i, map[0 := val])
+    // }
+
+    // function MergeAt(i: Idx, vals: map<Variable, M.Any>): State 
+    //   ensures |MergeAt(i, vals)| >= i + |vals|
+    //   ensures |MergeAt(i, vals)| >= |this|
+    //   ensures forall j: Idx :: j < |this| ==> j < i || j >= i + |vals| ==> MergeAt(i, vals)[j] == this[j]
+    //   ensures forall j: Idx :: i <= j < i + |vals| ==> MergeAt(i, vals)[j] == vals[j - i]
+    // {
+    //   var m := map j: Idx | j < |vals| :: vals[j];
+    //   ghost var m' := if m.Keys == {} then 0 else Max(m.Keys);
+    //   assert m' + 1 >= |vals| by {
+    //     if vals != [] {
+    //       assert |vals| - 1 in m.Keys;
+    //     }
+    //   }
+    //   UpdateMapShift(i, m)
+    // }
+
+    ghost function EqExcept(vars: set<Variable>) : iset<State>
+    {
+      iset st': State | 
+        && st'.Keys <= Keys
+        && forall v: Variable :: v in st'.Keys && v !in vars ==> st'[v] == this[v]
+    }
+
+  }
+
+  ghost function UpdateSet(vars: set<Variable>, post: iset<State>): iset<State> 
+  {
+    iset st: State | st.Without(vars) in post 
+  }
+
+  ghost const   AllStates: iset<State> := iset st: State | true
+
+  ghost function DeleteSet(vars: set<Variable>, post: iset<State>): iset<State> {
+    iset st: State {:trigger} | exists st' <- post :: st == st'.Without(vars)
+  }
+
+}

--- a/src/Sound/Semantics/Omni.dfy
+++ b/src/Sound/Semantics/Omni.dfy
@@ -1,0 +1,659 @@
+module Omni {
+  import opened Utils
+  import opened State
+  import M = Model
+  import opened Expr
+  import opened AST
+  export
+    provides Utils, AST, State, Expr,
+      SeqLemma, SemNest, SemCons, SeqSemCons, SeqSemSingle, 
+      RefSem, SeqRefSem, SemSoundProcs, 
+      SingleCont,
+      SemLoopWithCont, InvSem, Continuation.Update0, 
+      SemConsDepthLemma, SemPostCheckLemma, SemFrameFirst
+    reveals 
+      Sem, SeqSem, WP, SeqWP, SemSingle, 
+      Continuation, Continuation.Update, Continuation.UpdateAndAdd, Continuation.head, 
+      Continuation.Leq, Continuation.LeqDepth,
+      Continuation.UpdateHead, PreservesInv, Continuation.Get, 
+      RefProcedureIsSound, RefProcedureIsSoundWith,
+      ProcedureIsSound
+
+  newtype Continuation = s: seq<iset<State>> | |s| > 0 witness [iset{}] {
+
+    function Get(i: nat): iset<State> 
+      requires i < |this|
+    {
+      this[i]
+    }
+
+    ghost const head : iset<State> := this[0]
+
+    function Cons(post: iset<State>): Continuation {
+      [post] + this
+    }
+
+    ghost function UpdateHead(post: iset<State>): Continuation {
+      this[0 := post]
+    }
+
+    ghost function Update(variablesInScope: set<Variable>): Continuation 
+      ensures |this| == |Update(variablesInScope)|
+      ensures forall l: nat :: l < |this| ==> Update(variablesInScope)[l] == UpdateSet(variablesInScope, this[l])
+    {
+      var head' := UpdateSet(variablesInScope, head);
+      if |this| == 1 then [head'] else [head'] + this[1..].Update(variablesInScope)
+    }
+
+    lemma Update0()
+      ensures Update({}) == this
+    {
+      assert forall st: State :: st.Without({}) == st;
+      assert UpdateSet({}, head) == head;
+      if |this| == 1 {
+      } else {
+        this[1..].Update0();
+      }
+    }
+
+    ghost function UpdateAndAdd(variablesInScope: set<Variable>): Continuation {
+      ([head] + this).Update(variablesInScope)
+    }
+
+    predicate Leq(cont2: Continuation) {
+      && |this| == |cont2|
+      && forall i: nat :: i < |this| ==> this[i] <= cont2[i]
+    }
+
+    predicate LeqDepth(cont2: Continuation, n: nat) {
+      && |this| > n
+      && |cont2| > n
+      && forall i: nat :: i <= n ==> this[i] <= cont2[i]
+    }
+
+    lemma LeqUpdate(variablesInScope: set<Variable>, cont: Continuation) 
+      requires Leq(cont) 
+      ensures Update(variablesInScope).Leq(cont.Update(variablesInScope))
+    {
+
+    }
+
+    lemma LeqDepthUpdate(variablesInScope: set<Variable>, cont: Continuation, n: nat)
+      requires LeqDepth(cont, n)
+      ensures Update(variablesInScope).LeqDepth(cont.Update(variablesInScope), n)
+    {
+
+    }
+
+    lemma LeqUpdateAndAdd(variablesInScope: set<Variable>, cont: Continuation) 
+      requires Leq(cont) 
+      ensures UpdateAndAdd(variablesInScope).Leq(cont.UpdateAndAdd(variablesInScope))
+    {
+      ([head] + this).LeqUpdate(variablesInScope, [cont.head] + cont);
+    }
+
+    lemma LeqDepthUpdateAndAdd(variablesInScope: set<Variable>, cont: Continuation, n: nat)
+      requires LeqDepth(cont, n)
+      ensures UpdateAndAdd(variablesInScope).LeqDepth(cont.UpdateAndAdd(variablesInScope), n)
+    {
+      ([head] + this).LeqDepthUpdate(variablesInScope, [cont.head] + cont, n);
+    }
+
+    lemma LeqUpdateHead(post: iset<State>, cont: Continuation) 
+      requires Leq(cont) 
+      ensures UpdateHead(post).Leq(cont.UpdateHead(post))
+    {
+    }
+
+    lemma LeqDepthUpdateHead(post: iset<State>, cont: Continuation, n: nat)
+      requires LeqDepth(cont, n)
+      ensures UpdateHead(post).LeqDepth(cont.UpdateHead(post), n)
+    {
+    }
+  }
+
+  function SingleCont(post: iset<State>): Continuation { 
+    [post]
+  }
+
+  ghost predicate SemSingle(s: Stmt, st: State, post: iset<State>, m: M.Model) 
+    requires s.Single()
+    // reads *
+  {
+    match s
+    case Check(e)       => 
+      && e.IsDefinedOn(st.Keys) 
+      && (e.HoldsOn(st, m) &&  st in post)
+    case Assume(e)      => 
+      && e.IsDefinedOn(st.Keys) 
+      && (e.HoldsOn(st, m) ==> st in post)
+    case Assign(x, v)   =>
+        && x in st.Keys
+        && v.IsDefinedOn(st.Keys)
+        && v.Eval(st, m).Some? 
+        && st[x := v.Eval(st, m).value] in post
+    case Call(proc, args) =>
+      && args.IsDefinedOn(st.Keys)
+      && var callSt := args.Eval(st);
+        && (forall e <- proc.Pre :: e.IsDefinedOn(callSt.Keys) && e.HoldsOn(callSt, m))
+        && forall st': State :: (
+          && st' in st.EqExcept(args.OutArgs())
+          && st'.Keys == st.Keys
+          && var callSt' := args.Eval(st') /* + args.EvalOld(st)*/; 
+            (forall e <- proc.Post :: e.IsDefinedOn(callSt'.Keys) && e.HoldsOn(callSt', m)))
+              ==> st' in post
+  }
+
+  ghost predicate PreservesInv(inv: iset<State>, body: Stmt, posts: Continuation, m: M.Model, st: State)
+  { 
+    forall st': State :: 
+      st' in inv ==> Sem(body, st', posts.UpdateHead(inv), m)
+  }
+
+  ghost predicate Sem(s: Stmt, st: State, posts: Continuation, m: M.Model) 
+  {
+    if s.Single() then SemSingle(s, st, posts.head, m) else
+    match s
+    case Seq(ss)        => SeqSem(ss, st, posts, m)
+    case Choice(s0, s1) => Sem(s0, st, posts, m) && Sem(s1, st, posts, m)
+    case NewScope(vars, s) => 
+      forall vs: State :: vs.Keys == vars ==> Sem(s, st.Update(vs as map), posts.UpdateAndAdd(vars), m)
+    case Escape(l)      => |posts| > l && st in posts[l]
+    case Loop(_, body) => 
+      exists inv: iset<State> :: 
+        && st in inv
+        && forall st': State :: 
+          st' in inv ==> Sem(body, st', posts.UpdateHead(inv), m)
+  }
+
+  greatest predicate RefSem(s: Stmt, st: State, posts: Continuation, m: M.Model) 
+    reads *
+  {
+    match s
+    case Check(e)       => 
+      e.RefHoldsOn(st, m) &&  st in posts.head
+    case Assume(e)      =>  
+      e.RefHoldsOn(st, m) ==> st in posts.head
+    case Assign(x, e)   => 
+      && x in st.Keys
+      && exists v: M.Any ::
+        && e.RefEval(st, iset{v}, m)
+        && st.UpdateAt(x, v) in posts.head
+    case Call(proc, args) => 
+      && RefProcedureIsSound(proc, m)
+      && args.IsDefinedOn(st.Keys)
+      && var callSt := args.Eval(st);
+        && (forall e <- proc.Pre :: e.RefHoldsOn(callSt, m))
+        && forall st': State :: (
+          && st' in st.EqExcept(args.OutArgs())
+          && st'.Keys == st.Keys
+          && var callSt' := args.Eval(st') /*+ args.EvalOld(st)*/;
+            (forall e <- proc.Post :: e.RefHoldsOn(callSt', m)))
+              ==> st' in posts.head
+    case Seq(ss)        => SeqRefSem(ss, st, posts, m)
+    case Choice(s0, s1) => RefSem(s0, st, posts, m) && RefSem(s1, st, posts, m)
+    case NewScope(n, s) => 
+      forall vs: State :: vs.Keys == n ==> RefSem(s, st.Update(vs as map), posts.UpdateAndAdd(n), m)
+    case Escape(l)      => |posts| > l && st in posts[l]
+    case Loop(inv, body) => RefSem(Seq([body, Loop(inv, body)]), st, posts, m)
+  }
+
+  greatest predicate SeqRefSem(ss: seq<Stmt>, st: State, posts: Continuation, m: M.Model) 
+    reads *
+  {
+    if ss == [] then st in posts.head else
+    forall post': iset<State> :: 
+      (forall st: State :: SeqRefSem(ss[1..], st, posts, m) ==> st in post') ==> RefSem(ss[0], st, posts.UpdateHead(post'), m)
+  }
+
+  greatest predicate RefProcedureIsSound(proc: Procedure, m: M.Model) 
+    reads *
+  {
+    proc.Body.Some? ==>
+      forall st: State :: st in proc.PreSet(m) ==>
+        RefSem(proc.Body.value, st, SingleCont(proc.PostSet(m)), m)
+  }
+
+  ghost predicate RefProcedureIsSoundWith(proc: Procedure, funs: set<Function>)
+    reads *
+  {
+    forall md: M.Model ::
+      (forall func <- funs :: func.IsSound(md)) ==>
+        RefProcedureIsSound(proc, md)
+  }
+
+  ghost predicate ProcedureIsSound(proc: Procedure, m: M.Model) 
+    reads *
+  {
+    proc.Body.Some? ==>
+      forall st: State :: st in proc.PreSet(m) ==>
+        Sem(proc.Body.value, st, [proc.PostSet(m)], m)
+  }
+ 
+  ghost function WP(s: Stmt, posts: Continuation, m: M.Model) : iset<State> 
+    reads *
+  {
+    iset st: State | Sem(s, st, posts, m)
+  }
+
+  ghost predicate SeqSem(ss: seq<Stmt>, st: State, posts: Continuation, m: M.Model) 
+  {
+    if ss == [] then st in posts.head else
+    forall post': iset<State> :: 
+      (forall st: State :: SeqSem(ss[1..], st, posts, m) ==> st in post') ==> Sem(ss[0], st, posts.UpdateHead(post'), m)
+  }
+
+  ghost function SeqWP(ss: seq<Stmt>, cont: Continuation, m: M.Model): iset<State> 
+  {
+    iset st: State | SeqSem(ss, st, cont, m)
+  }
+
+  lemma SemCons(s: Stmt, st: State, posts: Continuation, posts': Continuation, m: M.Model)
+    requires Sem(s, st, posts, m)
+    requires posts.Leq(posts')
+    ensures Sem(s, st, posts', m)
+  {
+    match s
+    case Seq(ss) => SeqSemCons(ss, st, posts, posts', m);
+    case NewScope(n, s) => posts.LeqUpdateAndAdd(n, posts');
+    case Loop(_, body) => forall inv { posts.LeqUpdateHead(inv, posts'); }
+    case _ =>
+  }
+
+  lemma SeqSemCons(ss: seq<Stmt>, st: State, posts: Continuation, posts': Continuation, m: M.Model)
+    requires SeqSem(ss, st, posts, m)
+    requires posts.Leq(posts')
+    ensures SeqSem(ss, st, posts', m)
+  {
+    if ss != [] {
+      assert ss == [ss[0]] + ss[1..];
+      forall post': iset<State> | (forall st: State :: SeqSem(ss[1..], st, posts', m) ==> st in post') {
+        SemCons(ss[0], st, posts.UpdateHead(post'), posts'.UpdateHead(post'), m);
+      }
+    }
+  }
+
+  lemma SemNest(s: Stmt, ss: seq<Stmt>, st: State, posts: Continuation, m: M.Model) 
+    requires Sem(s, st, posts.UpdateHead(SeqWP(ss, posts, m)), m)
+    ensures SeqSem([s] + ss, st, posts, m)
+  {
+    forall post': iset<State> | (forall st: State :: SeqSem(ss, st, posts, m) ==> st in post') {
+      SemCons(s, st, posts.UpdateHead(SeqWP(ss, posts, m)), posts.UpdateHead(post'), m);
+    }
+  }
+
+  lemma SeqSemSingle(s: Stmt, st: State, posts: Continuation, m: M.Model)
+    requires SeqSem([s], st, posts, m)
+    ensures Sem(s, st, posts, m)
+  {
+    assert [s][0] == s;
+    assert [s][1..] == [];
+    assert posts == posts.UpdateHead(posts.head);
+  }
+
+  lemma SeqSemNest(ss1: seq<Stmt>, ss2: seq<Stmt>, st: State, posts: Continuation, m: M.Model) 
+    requires SeqSem(ss1 + ss2, st, posts, m)
+    ensures SeqSem(ss1, st, posts.UpdateHead(SeqWP(ss2, posts, m)), m)
+  {
+    if ss1 == [] {
+      assert [] + ss2 == ss2;
+    } else {
+      assert ([ss1[0]] + (ss1[1..] + ss2))[0] == ss1[0];
+      assert ss1 + ss2 == [ss1[0]] + (ss1[1..] + ss2); 
+      assert forall post': iset<State> :: posts.UpdateHead(SeqWP(ss2, posts, m)).UpdateHead(post') == posts.UpdateHead(post');
+    }
+  }
+
+  lemma SeqLemma(ss1: seq<Stmt>, ss2: seq<Stmt>, st: State, posts: Continuation, m: M.Model)
+    requires Sem(Seq(ss1 + ss2), st, posts, m)
+    ensures SeqSem([Seq(ss1)] + ss2, st, posts, m)
+  {
+    SeqSemNest(ss1, ss2, st, posts, m);
+    SemNest(Seq(ss1), ss2, st, posts, m);
+  }
+
+  lemma SemSeqLemma(ss: seq<Stmt>, st: State, posts: Continuation, m: M.Model)
+    requires SeqSem(ss, st, posts, m)
+    ensures Sem(Seq(ss), st, posts, m)
+  {
+
+  }
+
+  lemma SeqSemSingle'(s: Stmt, st: State, posts: Continuation, m: M.Model)
+    requires Sem(s, st, posts, m)
+    ensures SeqSem([s], st, posts, m)
+  {
+    assert [s][0] == s;
+    assert [s][1..] == [];
+    assert posts.UpdateHead(posts.head) == posts;
+    forall post': iset<State> | (forall st: State :: SeqSem([], st, posts, m) ==> st in post') 
+      ensures Sem(s, st, posts.UpdateHead(post'), m) {
+      SemCons(s, st, posts, posts.UpdateHead(post'), m);
+    }
+  }
+
+  lemma SemLoopLemma(inv: Expr, body: Stmt, st: State, posts: Continuation, inv': iset<State>, m: M.Model)
+    requires st in inv'
+    requires forall st': State :: 
+      st' in inv' ==> Sem(body, st', posts.UpdateHead(inv'), m)
+    ensures Sem(Loop(inv, body), st, posts, m)
+  {  }
+
+  lemma PreservesInvLemma(inv: iset<State>, body: Stmt, posts: Continuation, m: M.Model, st: State)
+    requires PreservesInv(inv, body, posts, m, st)
+    ensures forall st': State :: 
+      st' in inv ==> Sem(body, st', posts.UpdateHead(inv), m)
+  {  } 
+
+  ghost function WithSubVars(posts: Continuation, vars: set<Variable>): Continuation
+  {
+    seq(|posts|, (i: nat) requires i < |posts| => iset st': State | st' in posts[i] && vars <= st'.Keys)
+  }
+
+  lemma SemFrame(s: Stmt, st: State, posts: Continuation, m: M.Model, vars: set<Variable>)
+    requires Sem(s, st, posts, m)
+    requires s.VariablesDistinct(vars)
+    requires vars <= st.Keys
+    ensures Sem(s, st, WithSubVars(posts, vars), m) 
+  {
+    match s
+    case Seq(ss) => SeqSemFrame(ss, st, posts, m, vars);
+    case NewScope(vars', s) => 
+      forall vs: State | vs.Keys == vars'
+        ensures Sem(s, st.Update(vs as map), WithSubVars(posts, vars).UpdateAndAdd(vars'), m) {
+        SemFrame(s, st.Update(vs as map), posts.UpdateAndAdd(vars'), m, vars + vars');
+        SemCons(s, st.Update(vs as map), WithSubVars(posts.UpdateAndAdd(vars'), vars + vars'), WithSubVars(posts, vars).UpdateAndAdd(vars'), m);
+      }
+    case Loop(inv, body) => 
+      var invEx :| st in invEx && PreservesInv(invEx, body, posts, m, st);
+      var invEx' := invEx * iset st': State | vars <= st'.Keys;
+      assert st in invEx';
+      forall st': State | st' in invEx'
+        ensures Sem(body, st', WithSubVars(posts, vars).UpdateHead(invEx'), m) {
+        PreservesInvLemma(invEx, body, posts, m, st);
+        SemFrame(body, st', posts.UpdateHead(invEx), m, vars);
+        SemCons(body, st', WithSubVars(posts.UpdateHead(invEx), vars), WithSubVars(posts, vars).UpdateHead(invEx'), m);
+      }
+    case _ =>
+  }
+
+  lemma SeqSemFrame(ss: seq<Stmt>, st: State, posts: Continuation, m: M.Model, vars: set<Variable>)
+    requires SeqSem(ss, st, posts, m)
+    requires SeqVariablesDistinct(ss, vars)
+    requires vars <= st.Keys
+    ensures SeqSem(ss, st, WithSubVars(posts, vars), m)
+  {
+    if ss != [] {
+      assert ss == [ss[0]] + ss[1..];
+      calc {
+        SeqSem(ss, st, WithSubVars(posts, vars), m);
+        <== { SemNest(ss[0], ss[1..], st, WithSubVars(posts, vars), m); }
+        Sem(ss[0], st, WithSubVars(posts, vars).UpdateHead(SeqWP(ss[1..], WithSubVars(posts, vars), m)), m);
+        <== { SemCons(ss[0], st, WithSubVars(posts.UpdateHead(SeqWP(ss[1..], posts, m)), vars),
+                                 WithSubVars(posts, vars).UpdateHead(SeqWP(ss[1..], WithSubVars(posts, vars), m)), m); }
+        Sem(ss[0], st, WithSubVars(posts.UpdateHead(SeqWP(ss[1..], posts, m)), vars), m);
+        <== { SemFrame(ss[0], st, posts.UpdateHead(SeqWP(ss[1..], posts, m)), m, vars); }
+        Sem(ss[0], st, posts.UpdateHead(SeqWP(ss[1..], posts, m)), m);
+      }
+    }
+  }
+
+  lemma SemFrameFirst(s: Stmt, st: State, posts: Continuation, post: iset<State>, m: M.Model, vars: set<Variable>)
+    requires Sem(s, st, posts.UpdateHead(post), m)
+    requires s.VariablesDistinct(vars)
+    requires vars <= st.Keys
+    ensures Sem(s, st, posts.UpdateHead(post * iset st': State | vars <= st'.Keys), m) 
+  {
+    SemFrame(s, st, posts.UpdateHead(post), m, vars);
+    SemCons(s, st, WithSubVars(posts.UpdateHead(post), vars), posts.UpdateHead(post * iset st': State | vars <= st'.Keys), m);
+  }
+
+  lemma SemLoopUnroll(s: Stmt, inv: Expr, body: Stmt, st: State, posts: Continuation, m: M.Model)
+    requires Sem(Loop(inv, body), st, posts, m)
+    ensures Sem(Seq([body, Loop(inv, body)]), st, posts, m)
+  {
+    var invEx :| st in invEx && PreservesInv(invEx, body, posts, m, st);
+    PreservesInvLemma(invEx, body, posts, m, st);
+    SemNest(body, [Loop(inv, body)], st, posts, m) by {
+      SemCons(body, st, posts.UpdateHead(invEx), posts.UpdateHead(SeqWP([Loop(inv, body)], posts, m)), m) by {
+        forall st': State | st' in invEx ensures SeqSem([Loop(inv, body)], st', posts, m) {
+          SeqSemSingle'(Loop(inv, body), st', posts, m) by {
+            SemLoopLemma(inv, body, st', posts, invEx, m);
+          }
+        }
+      }
+    }
+  }
+
+  greatest lemma SemSound(s: Stmt, st: State, posts: Continuation, procs: set<Procedure>, funs: set<Function>, m: M.Model)
+    requires Sem(s, st, posts, m)
+    requires s.ProceduresCalled() <= procs
+    requires s.FunctionsCalled() <= funs
+    requires forall p <- procs :: p.ProceduresCalled() <= procs
+    requires forall p <- procs :: p.FunctionsCalled() <= funs
+    requires forall f <- funs :: f.FunctionsCalled() <= funs
+    requires forall p <- procs :: ProcedureIsSound(p, m)
+    requires forall f <- funs :: f.IsSound(m)
+    ensures RefSem(s, st, posts, m)
+  {
+      match s
+      case Seq(ss) => SeqSemSound(ss, st, posts, procs, funs, m);
+      case Loop(inv, body) => 
+        SemLoopUnroll(s, inv, body, st, posts, m);
+        SemSound(Seq([body, Loop(inv, body)]), st, posts, procs, funs, m) by {
+          forall p <- SeqProceduresCalled([body, Loop(inv, body)])
+            ensures p in s.ProceduresCalled()
+          {
+            calc {
+              SeqProceduresCalled([body, Loop(inv, body)]);
+              ==
+              body.ProceduresCalled() + SeqProceduresCalled([Loop(inv, body)]);
+              == 
+              body.ProceduresCalled() + Loop(inv, body).ProceduresCalled() + SeqProceduresCalled([]);
+            }
+          }
+          forall f <- SeqFunctionsCalled([body, Loop(inv, body)])
+            ensures f in s.FunctionsCalled()
+          {
+            calc {
+              SeqFunctionsCalled([body, Loop(inv, body)]);
+              ==
+              body.FunctionsCalled() + SeqFunctionsCalled([Loop(inv, body)]);
+              == 
+              body.FunctionsCalled() + Loop(inv, body).FunctionsCalled() + SeqFunctionsCalled([]);
+            }
+          }
+
+        }
+      case Call(proc, args) => 
+        var callSt := args.Eval(st);
+        forall e <- proc.Pre ensures e.RefHoldsOn(callSt, m) {
+          e.HoldsOnSound(callSt, funs, m) by {
+            SeqExprFunctionsCalledIn(proc.Pre, e);
+          }
+        }
+        forall post <- proc.Post, st 
+          ensures post.RefHoldsOn(st, m) == (post.IsDefinedOn(st.Keys) && post.HoldsOn(st, m))
+        {
+          post.HoldsOnSound(st, funs, m) by {
+            SeqExprFunctionsCalledIn(proc.Post, post);
+          }
+        }
+        assert ProcedureIsSound(proc, m);
+        ProcedureIsSoundSound(proc, procs, funs, m);
+      case Assume(e) => e.HoldsOnSound(st, funs, m);
+      case Check(e) => e.HoldsOnSound(st, funs, m);
+      case Assign(x, e) => e.EvalSound(st, funs, iset{e.Eval(st, m).value}, m);
+      case _ =>
+  }
+
+  greatest lemma ProcedureIsSoundSound(proc: Procedure, procs: set<Procedure>, funs: set<Function>, m: M.Model)
+    requires ProcedureIsSound(proc, m)
+    requires proc.ProceduresCalled() <= procs
+    requires proc.FunctionsCalled() <= funs
+    requires forall f <- funs :: f.IsSound(m)
+    requires forall f <- funs :: f.FunctionsCalled() <= funs
+    requires forall p <- procs :: p.ProceduresCalled() <= procs
+    requires forall p <- procs :: ProcedureIsSound(p, m)
+    requires forall p <- procs :: p.FunctionsCalled() <= funs
+    ensures RefProcedureIsSound(proc, m)
+  {
+    if proc.Body.Some? {
+      forall st: State | st in proc.PreSet(m)
+        ensures RefSem(proc.Body.value, st, SingleCont(proc.PostSet(m)), m) {
+        SemSound(proc.Body.value, st, SingleCont(proc.PostSet(m)), procs, funs, m);
+      }
+    }
+  }
+
+  greatest lemma SeqSemSound(ss: seq<Stmt>, st: State, posts: Continuation, procs: set<Procedure>, funs: set<Function>, m: M.Model)
+    requires SeqSem(ss, st, posts, m)
+    requires SeqProceduresCalled(ss) <= procs
+    requires SeqFunctionsCalled(ss) <= funs
+    requires forall p <- procs :: p.ProceduresCalled() <= procs
+    requires forall f <- funs :: f.FunctionsCalled() <= funs
+    requires forall p <- procs :: ProcedureIsSound(p, m)
+    requires forall p <- procs :: p.FunctionsCalled() <= funs
+    requires forall f <- funs :: f.IsSound(m)
+    ensures SeqRefSem(ss, st, posts, m)
+  {
+    if ss != [] {
+      forall post': iset<State> | (forall st: State :: SeqRefSem(ss[1..], st, posts, m) ==> st in post') 
+        ensures RefSem(ss[0], st, posts.UpdateHead(post'), m) {
+        SemSound(ss[0], st, posts.UpdateHead(post'), procs, funs, m);
+      }
+    }
+  }
+
+  lemma SemSoundProc(proc: Procedure, procs: set<Procedure>, funs: set<Function>, m: M.Model)
+    requires proc in procs
+    requires proc.ProceduresCalled() <= procs
+    requires proc.FunctionsCalled() <= funs
+    requires forall f <- funs :: f.IsSound(m)
+    requires forall f <- funs :: f.FunctionsCalled() <= funs
+    requires forall p <- procs :: p.ProceduresCalled() <= procs
+    requires forall p <- procs :: p.FunctionsCalled() <= funs
+    requires forall p <- procs :: ProcedureIsSound(p, m)
+    ensures RefProcedureIsSound(proc, m)
+  {
+    if proc.Body.Some? {
+      forall st: State | st in proc.PreSet(m)
+        ensures RefSem(proc.Body.value, st, SingleCont(proc.PostSet(m)), m) {
+        SemSound(proc.Body.value, st, SingleCont(proc.PostSet(m)), procs, funs, m);
+      }
+    }
+  }
+
+  lemma SemSoundProcs(procs: set<Procedure>, funcs: set<Function>, m: M.Model)
+    requires forall proc <- procs :: proc.Valid()
+    requires forall proc <- procs :: ProcedureIsSound(proc, m)
+    requires forall func <- funcs :: func.IsSound(m)
+    requires forall proc <- procs :: proc.ProceduresCalled() <= procs
+    requires forall proc <- procs :: proc.FunctionsCalled() <= funcs
+    requires forall func <- funcs :: func.FunctionsCalled() <= funcs
+    ensures  forall proc <- procs :: RefProcedureIsSound(proc, m)
+  {
+    forall proc <- procs 
+      ensures RefProcedureIsSound(proc, m) {
+      SemSoundProc(proc, procs, funcs, m);
+    }
+  }
+
+  lemma SemLoopWithCont(inv: Expr, body: Stmt, cont: seq<Stmt>, st: State, posts: Continuation, inv': iset<State>, m: M.Model)
+    requires st in inv'
+    requires forall st': State :: 
+      st' in inv' /*&& st.Keys == st'.Keys*/ ==> Sem(body, st', posts.UpdateHead(inv'), m)
+    ensures SeqSem([Loop(inv, body)] + cont, st, posts, m)
+  {
+    SemNest(Loop(inv, body), cont, st, posts, m) by {
+      SemLoopLemma(inv, body, st, posts.UpdateHead(SeqWP(cont, posts, m)), inv', m) by {
+        assert posts.UpdateHead(SeqWP(cont, posts, m)).UpdateHead(inv') == posts.UpdateHead(inv');
+      }
+    }
+  }
+  
+  lemma SemConsDepthLemma(s: Stmt, st: State, posts: Continuation, posts': Continuation, n: nat, m: M.Model)
+    requires Sem(s, st, posts, m)
+    requires posts.LeqDepth(posts', n)
+    requires s.JumpsDefinedOn(n)
+    ensures Sem(s, st, posts', m)
+  {
+    match s
+    case Seq(ss) => SeqSemConsDepthLemma(ss, st, posts, posts', n, m);
+    case NewScope(vars, s) => 
+      forall vs: State | vs.Keys == vars
+        ensures Sem(s, st.Update(vs as map), posts'.UpdateAndAdd(vars), m) {
+        if s.JumpDepth() == 0 {
+          SemConsDepthLemma(s, st.Update(vs as map), posts.UpdateAndAdd(vars), posts'.UpdateAndAdd(vars), 0, m);
+        } else {
+          posts.LeqDepthUpdateAndAdd(vars, posts', n);
+          SemConsDepthLemma(s, st.Update(vs as map), posts.UpdateAndAdd(vars), posts'.UpdateAndAdd(vars), n + 1, m);
+        }
+      }
+    case Loop(_, body) => forall inv { posts.LeqDepthUpdateHead(inv, posts', n); }
+    case _ =>
+  }
+
+  lemma SeqSemConsDepthLemma(ss: seq<Stmt>, st: State, posts: Continuation, posts': Continuation, n: nat, m: M.Model)
+    requires SeqSem(ss, st, posts, m)
+    requires posts.LeqDepth(posts', n)
+    requires SeqJumpsDefinedOn(ss, n)
+    ensures SeqSem(ss, st, posts', m)
+  {
+    if ss != [] {
+      assert ss == [ss[0]] + ss[1..];
+      forall post': iset<State> | (forall st: State :: SeqSem(ss[1..], st, posts', m) ==> st in post') {
+        SemConsDepthLemma(ss[0], st, posts.UpdateHead(post'), posts'.UpdateHead(post'), n, m);
+      }
+    }
+  }
+
+  lemma InvSem(inv: Expr, body: Stmt, st: State, posts: Continuation, stmt: Stmt, m: M.Model)
+    requires SeqSem([Assume(inv), body, Check(inv), stmt], st, posts, m)
+    requires st in inv.Sem(m)
+    ensures Sem(body, st, posts.UpdateHead(inv.Sem(m)), m)
+  {
+    SeqSemNest([Assume(inv)], [body, Check(inv), stmt], st, posts, m);
+    SeqSemSingle(Assume(inv), st, posts.UpdateHead(SeqWP([body, Check(inv), stmt], posts, m)), m);
+    assert SeqSem([body, Check(inv), stmt], st, posts, m);
+    SeqSemNest([body], [Check(inv), stmt], st, posts, m);
+    SeqSemSingle(body, st, posts.UpdateHead(SeqWP([Check(inv), stmt], posts, m)), m);
+    SemCons(body, st, posts.UpdateHead(SeqWP([Check(inv), stmt], posts, m)), posts.UpdateHead(inv.Sem(m)), m) by {
+      forall st': State | SeqSem([Check(inv), stmt], st', posts, m) ensures st' in inv.Sem(m) {
+        SeqSemNest([Check(inv)], [stmt], st', posts, m);
+        SeqSemSingle(Check(inv), st', posts.UpdateHead(SeqWP([stmt], posts, m)), m);
+      }
+    }
+  }
+
+  lemma SemPostCheck'Lemma(proc: Procedure, st: State, posts: Continuation, p: seq<Expr>, m: M.Model)
+    requires forall e <- p :: e.IsDefinedOn(proc.ParametersKeys() /*+ proc.NumInOutArgs()*/)
+    requires SeqSem(proc.PostCheck'(p), st, posts, m)
+    ensures forall e <- p :: e.IsDefinedOn(st.Keys) && e.HoldsOn(st, m)
+  {
+    if p != [] {
+      forall e <- p 
+        ensures e.IsDefinedOn(st.Keys) && e.HoldsOn(st, m) {
+        SeqSemNest([Check(p[0])], proc.PostCheck'(p[1..]), st, posts, m) by {
+          assert forall e <- p[1..] :: e in p;
+        }
+        if e in p[1..] {
+          SemPostCheck'Lemma(proc, st, posts, p[1..], m) by {
+            forall e <- p[1..]
+              ensures e.IsDefinedOn(proc.ParametersKeys() /*+ proc.NumInOutArgs()*/) {
+              assert e in p;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  lemma SemPostCheckLemma(proc: Procedure, st: State, posts: Continuation, m: M.Model)
+    requires proc.Valid()
+    requires SeqSem(proc.PostCheck(), st, posts, m)
+    ensures forall e <- proc.Post :: e.IsDefinedOn(st.Keys) && e.HoldsOn(st, m)
+  {
+    SemPostCheck'Lemma(proc, st, posts, proc.Post, m);
+  }
+}

--- a/src/Sound/Utils.dfy
+++ b/src/Sound/Utils.dfy
@@ -1,0 +1,109 @@
+module Utils { 
+
+  import opened Std.Wrappers
+
+  function SetOfSeq<T>(s: seq<T>): set<T> {
+    set x | x in s
+  }
+
+  function Index<T(==)>(ss: seq<T>, e: T): nat
+    requires e in ss
+    ensures Index(ss, e) < |ss|
+    ensures ss[Index(ss, e)] == e
+  {
+    if |ss| == 1 then 
+      0
+    else
+      if ss[0] == e then
+        0
+      else
+        Index(ss[1..], e) + 1
+  }
+
+  function Max(s: set<nat>): (m: nat)
+    requires s != {}
+    ensures m in s && forall z :: z in s ==> z <= m
+  {
+    var x :| x in s;
+    if s == {x} then
+      x
+    else
+      var s' := s - {x};
+      assert s == s' + {x};
+      var y := Max(s');
+      max(x, y)
+  } by method {
+    m :| m in s;
+    var r := s - {m};
+    while r != {}
+      invariant r < s
+      invariant m in s && forall z :: z in s - r ==> z <= m
+    {
+      var x :| x in r;
+      assert forall z :: z in s - (r - {x}) ==> z in s - r || z == x;
+      r := r - {x};
+      if m < x {
+        m := x;
+      }
+    }
+    assert s - {} == s;
+  }
+
+  function Max'(s: set<nat>): (m: nat)
+    ensures (s == {} || m in s) && forall z :: z in s ==> z <= m
+  {
+    if s == {} then 0 else Max(s)
+  }
+
+  lemma MaxLemma(s: set<nat>, i: nat, m: nat)
+    requires i + m in s
+    ensures i <= Max(s) - m
+  {
+    if s != {} {
+      var x :| x in s;
+    }
+  }
+
+  // function SeqTail<T>(n: nat, ss: seq<T>): seq<T> {
+  //   if |ss| <= n then [] else ss[n..]
+  // }
+
+  function max(x: nat, y: nat): nat {
+    if x > y then x else y
+  }
+  // function min(x: nat, y: nat): nat {
+  //   if x < y then x else y
+  // }
+
+  // function SeqMax(ss: seq<nat>): nat 
+  //   ensures forall i <- ss :: i <= SeqMax(ss)
+  //   ensures forall i: nat :: i < |ss| ==> ss[i] <= SeqMax(ss)
+  //   ensures ss != [] ==> SeqMax(ss) in ss
+  // {
+  //   if ss == [] then 
+  //     0 
+  //   else
+  //     assert ss == [ss[0]] + (ss[1..]);
+  //     max(ss[0], SeqMax(ss[1..]))
+  // }
+
+  datatype Except<+T> =
+    | Ok(res: T)
+    | Error
+  {
+    predicate IsFailure() {
+      Error?
+    }
+    function PropagateFailure<U>(): Except<U>
+      requires IsFailure()
+    {
+      Error
+    }
+    function Extract() : T 
+      requires !IsFailure()
+    {
+      res
+    }
+  }
+}
+

--- a/src/Sound/VCGen/AssignmentTarget.dfy
+++ b/src/Sound/VCGen/AssignmentTarget.dfy
@@ -1,0 +1,439 @@
+module AssignmentTarget {
+  import opened Utils
+  import opened AST
+  import opened State
+  import M = Model
+  import Omni
+
+//   export
+//     provides Utils, AST, M, Omni, State, Process, Correct
+//     reveals PairToSet
+  
+  newtype VarsJumps = map<nat, set<Variable>> {
+
+    ghost function Get(n: nat): iset<Variable> {
+      iset i: Variable | In(i, n)
+    }
+
+    ghost predicate In(i: Variable, n: nat) 
+    {
+      n in Keys && i in this[n]
+    }      
+
+    function Merge(m1: VarsJumps): VarsJumps {
+      map i: nat | i in Keys + m1.Keys :: 
+        if i in Keys then
+          if i in m1.Keys then
+            this[i] + m1[i]
+          else this[i]
+        else m1[i]
+    }
+
+    function Remove0(): VarsJumps {
+      var s0 := if 0 in Keys then this[0] else {};
+      map i: nat | i in Keys - {0} :: this[i] + s0
+    }
+
+    opaque function SeqMerge(m: VarsJumps): VarsJumps {
+      var s0 := if 0 in Keys then this[0] else {};
+      map i: nat | i in (Keys - {0}) + m.Keys :: 
+        if i in Keys then
+          if i in m.Keys then
+            this[i] + s0 + m[i]
+          else this[i]
+        else m[i] + s0
+    }
+
+    lemma SeqMergeKeys(m: VarsJumps)
+      ensures SeqMerge(m).Keys == Keys - {0} + m.Keys
+    {
+      reveal SeqMerge(m);
+    }
+
+    lemma SeqMergeGet1(m: VarsJumps, i: Variable, k: nat)
+      requires i in Get(0)
+      requires k in m.Keys
+      ensures i in SeqMerge(m).Get(k)
+    {
+      reveal SeqMerge(m);
+    }
+
+    lemma SeqMergeGet1'(m: VarsJumps, i: Variable, k: nat)
+      requires i in Get(k)
+      requires k in Keys
+      requires k != 0
+      ensures i in SeqMerge(m).Get(k)
+    {
+      reveal SeqMerge(m);
+    }
+
+    lemma SeqMergeGet2(m: VarsJumps, i: Variable, k: nat)
+      requires i in m.Get(k)
+      requires k in m.Keys
+      ensures i in SeqMerge(m).Get(k)
+    {
+      reveal SeqMerge(m);
+      var k' :| k' <= k && k' in m.Keys && i in m[k'];
+    }
+
+    function SubstractSet(vars: set<Variable>, s: set<Variable>): set<Variable> 
+      // ensures forall i: Variable :: i + n in s ==> i in SubstractSet(n, s)
+    {
+      s - vars
+      // set i: Variable {:trigger i + n in s} | i <= Max'(s) - n && i + n in s 
+    }
+
+    opaque function Substract(vars: set<Variable>): VarsJumps 
+    {
+      var m: VarsJumps := map i: nat {: trigger} | 
+        && i <= Max'(Keys) + 1
+        && i + 1 in Keys :: SubstractSet(vars, this[i + 1]);
+      if 0 in m.Keys && 0 in Keys then 
+        m[0 := m[0] + SubstractSet(vars, this[0])]
+      else if 0 in Keys then 
+        m[0 := SubstractSet(vars, this[0])]
+      else m
+    }
+
+    lemma SubstractPlusOne(vars: set<Variable>, i: nat)
+      requires i + 1 in Keys
+      ensures i in Substract(vars).Keys
+    {
+      reveal Substract(vars);
+    }
+
+    lemma SubstractZero(vars: set<Variable>)
+      requires 0 in Keys
+      ensures 0 in Substract(vars).Keys
+    {
+      reveal Substract(vars);
+    }
+
+    lemma SubstractGetZero(vars: set<Variable>, i: Variable)
+      requires i in Get(0)
+      requires i !in vars
+      requires 0 in Keys
+      ensures i in Substract(vars).Get(0)
+    {
+      SubstractZero(vars);
+      reveal Substract(vars);
+    }
+
+    lemma SubstractGet(vars: set<Variable>, i: Variable, k: nat)
+      requires i in Get(k)
+      requires k > 0
+      requires i !in vars
+      ensures i in Substract(vars).Get(k - 1) 
+    {
+      reveal Substract(vars);
+    }
+
+    lemma SubstracOfPlusOne(vars: set<Variable>, i: nat)
+      requires i + 1 in Keys
+      requires i in Substract(vars).Keys
+      ensures Substract(vars)[i] >= SubstractSet(vars, this[i + 1])
+    {
+      reveal Substract(vars);
+    }
+
+    ghost function ToEqs(st: State, posts: Omni.Continuation): Omni.Continuation 
+    {
+      seq(|posts|, (k : nat) requires k < |posts| => 
+        if k !in Keys then iset{} else
+        iset st' |
+          && st' in posts[k]
+          && st'.Keys <= st.Keys
+          && forall i: Variable :: i in st'.Keys && !(i in Get(k)) ==> st[i] == st'[i]
+      )
+    }
+
+    ghost function ToEqsAll(st: State): iset<State>
+    {
+        iset st': State |
+          && st'.Keys <= st.Keys
+          && forall i: Variable :: i in st'.Keys && !(i in Get(0)) ==> st[i] == st'[i]
+    }
+
+    lemma GetLemma(n: nat)
+      requires n in Keys
+      requires n != 0
+      ensures Get(n) <= Remove0().Get(n)
+    {
+      if 0 in Keys {
+        forall i: Variable | i in Get(n) ensures i in Remove0().Get(n) {
+          var k :| k <= n && k in Keys && i in this[k];
+          if k != 0 {
+            assert k in Remove0().Keys;
+            assert this[k] <= Remove0()[k];
+          } else {
+            assert n in Remove0().Keys;
+          }
+        }
+      } else {
+        forall i: Variable | i in Get(n) ensures i in Remove0().Get(n) {
+          var k :| k <= n && k in Keys && i in this[k];
+          assert Remove0().Keys == Keys;
+          assert k in Remove0().Keys;
+        }
+      }
+    }
+  }
+  
+  function Process'(stmt: Stmt): VarsJumps 
+    requires stmt.ValidCalls()
+    ensures forall v <- Process'(stmt).Values, s <- v :: s in stmt.FVars()
+    decreases stmt
+  {
+    match stmt
+    case Seq(ss) => SeqProcess'(ss)
+    case Choice(s0, s1) => 
+      var vs0 := Process'(s0);
+      var vs1 := Process'(s1);
+      vs0.Merge(vs1)
+    case NewScope(n, s) => 
+      var vs := Process'(s);
+      reveal vs.Substract(n);
+      vs.Substract(n)
+    case Escape(n) => map[n := {}]
+    /**
+      Loop
+        (x++) + (y++; exit 1)
+    We need to add all m[0] vars to other m[i] because 
+    loop modify 0 vars in first few operations and then
+    exit modify other vars
+    */
+    case Loop(inv, body) => Process'(body).Remove0()
+    case Assign(x, _) => map[0 := {x}]
+    case Call(proc, args) => 
+      args.OutArgsDepthLemma();
+      map[0 := args.OutArgs()]
+    case _ => map[0 := {}]
+  }
+
+  function SeqProcess'(ss: seq<Stmt>): VarsJumps 
+    requires SeqValidCalls(ss)
+    ensures forall v <- SeqProcess'(ss).Values, s <- v :: s in SeqFVars(ss)
+    decreases ss
+  {
+    if ss == [] then map[0 := {}] else
+      var v0 := Process'(ss[0]);
+      if 0 in v0.Keys then
+        reveal v0.SeqMerge(SeqProcess'(ss[1..]));
+        v0.SeqMerge(SeqProcess'(ss[1..]))
+      else v0
+  }
+
+  lemma Process'Correct(stmt: Stmt, st: State, m: VarsJumps, posts: Omni.Continuation, md: M.Model) 
+    requires stmt.ValidCalls()
+    requires Process'(stmt) == m
+    ensures forall v <- m.Values, s <- v :: s in stmt.FVars()
+    requires Omni.Sem(stmt, st, posts, md)
+    ensures Omni.Sem(stmt, st, m.ToEqs(st, posts), md)
+  {
+    match stmt 
+    case Choice(s0, s1) =>
+      var m0 := Process'(s0);
+      var m1 := Process'(s1);
+      Omni.SemCons(s0, st, m0.ToEqs(st, posts), m0.Merge(m1).ToEqs(st, posts), md) by {
+        Process'Correct(s0, st, m0, posts, md);
+      }
+      Omni.SemCons(s1, st, m1.ToEqs(st, posts), m0.Merge(m1).ToEqs(st, posts), md) by {
+        Process'Correct(s1, st, m1, posts, md);
+      }
+    case Loop(_, body) =>
+      var inv :| 
+        && st in inv
+        && Omni.PreservesInv(inv, body, posts, md, st);
+      var m' := Process'(body);
+      var inv' := inv * m'.ToEqsAll(st);
+      assert st in inv';
+      forall st': State | st' in inv' ensures Omni.Sem(body, st', (m'.Remove0()).ToEqs(st, posts).UpdateHead(inv'), md) {
+        Omni.SemCons(body, st', m'.ToEqs(st', posts.UpdateHead(inv)), (m'.Remove0()).ToEqs(st, posts).UpdateHead(inv'), md) by {
+          Process'Correct(body, st', m', posts.UpdateHead(inv), md) by {
+            assert Omni.PreservesInv(inv, body, posts, md, st);
+          }
+        }
+      }
+    case NewScope(vars, s) => 
+      forall vs: map<Variable, M.Any> | vs.Keys == vars ensures Omni.Sem(s, st.Update(vs), m.ToEqs(st, posts).UpdateAndAdd(vars), md) {
+        var m' := Process'(s);
+        Omni.SemCons(s, st.Update(vs), m'.ToEqs(st.Update(vs), posts.UpdateAndAdd(vars)), m.ToEqs(st, posts).UpdateAndAdd(vars), md) by {
+          Process'Correct(s, st.Update(vs), m', posts.UpdateAndAdd(vars), md);
+          forall i: nat | i < |posts| + 1 
+            ensures m'.ToEqs(st.Update(vs), posts.UpdateAndAdd(vars))[i] <=
+              m'.Substract(vars).ToEqs(st, posts).UpdateAndAdd(vars)[i]
+          {
+            forall st': State | st' in m'.ToEqs(st.Update(vs), posts.UpdateAndAdd(vars))[i] 
+              ensures st' in m'.Substract(vars).ToEqs(st, posts).UpdateAndAdd(vars)[i] {
+              assert st' in posts.UpdateAndAdd(vars)[i];
+              if i == 0 {
+                assert st'.Without(vars) in m'.Substract(vars).ToEqs(st, posts).head by {
+                  assert forall i: Variable :: i in st'.Keys && i !in vars && !(i in m'.Get(0)) ==> st.Update(vs)[i] == st'[i];
+                  if 0 in m'.Keys {
+                    assert 0 in m'.Substract(vars).Keys by { m'.SubstractZero(vars); }
+                    assert st'.Without(vars) in m'.Substract(vars).ToEqs(st, posts).head by {
+                      forall i: Variable | i in st'.Without(vars).Keys && !(i in m'.Substract(vars).Get(0)) 
+                        ensures st[i] == st'.Without(vars)[i] {
+                        assert !(i in m'.Get(0) && i !in vars) by {
+                          if i in m'.Get(0) && i !in vars {
+                            m'.SubstractGetZero(vars, i); 
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              } else {
+                assert st'.Without(vars) in m'.Substract(vars).ToEqs(st, posts)[i - 1] by {
+                  
+                  if i in m'.Keys {
+                    
+                    assert st'.Without(vars) in posts[i - 1] by {
+                      calc {
+                        st'.Without(vars) in posts[i - 1];
+                        st' in posts.UpdateAndAdd(vars)[i];
+                      }
+                    }
+                    assert (i - 1) in m'.Substract(vars).Keys by {
+                      m'.SubstractPlusOne(vars, i - 1);
+                    }
+                    
+                    forall j: Variable | j in st'.Without(vars).Keys && !(j in m'.Substract(vars).Get(i - 1)) 
+                      ensures st[j] == st'.Without(vars)[j] {
+                      assert !(j in m'.Get(i) && j !in vars) by {
+                        if j in m'.Get(i) && j !in vars {
+                          m'.SubstractGet(vars, j, i) by {
+                            assert j in m'.Get(i);
+                            assert i > 0;
+                            assert j !in vars;
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    case Seq(ss) => SeqProcess'Correct(ss, st, m, posts, md);
+    case Call(proc, args) => 
+      forall st': State |
+        && st' in st.EqExcept(args.OutArgs())
+        && st'.Keys == st.Keys
+        && var callSt' := args.Eval(st') /*+ args.EvalOld(st)*/;
+          (forall e <- proc.Post :: e.IsDefinedOn(callSt'.Keys) && e.HoldsOn(callSt', md))
+        ensures st' in m.ToEqs(st, posts).head
+      { assert st'.Keys <= st.Keys; }
+    case _ =>
+  }
+
+  lemma SeqProcess'Correct(ss: seq<Stmt>, st: State, m: VarsJumps, posts: Omni.Continuation, md: M.Model) 
+    requires SeqValidCalls(ss)
+    requires SeqProcess'(ss) == m
+    ensures forall v <- m.Values, s <- v :: s in SeqFVars(ss)
+    requires Omni.SeqSem(ss, st, posts, md)
+    ensures Omni.SeqSem(ss, st, m.ToEqs(st, posts), md)
+  {
+    if ss != [] {
+      Omni.SemNest(ss[0], ss[1..], st, m.ToEqs(st, posts), md) by {
+        assert Omni.Sem(ss[0], st, m.ToEqs(st, posts).UpdateHead(Omni.SeqWP(ss[1..],  m.ToEqs(st, posts), md)), md) by {
+          assert Omni.Sem(ss[0], st, posts.UpdateHead(Omni.SeqWP(ss[1..], posts, md)), md);
+          var m' := Process'(ss[0]);
+          var m'' := SeqProcess'(ss[1..]);
+          Process'Correct(ss[0], st, m', posts.UpdateHead(Omni.SeqWP(ss[1..], posts, md)), md);
+          assert Omni.Sem(ss[0], st, m'.ToEqs(st, posts.UpdateHead(Omni.SeqWP(ss[1..], posts, md))), md);
+          Omni.SemCons(ss[0], st, m'.ToEqs(st, posts.UpdateHead(Omni.SeqWP(ss[1..], posts, md))), 
+            m.ToEqs(st, posts).UpdateHead(Omni.SeqWP(ss[1..], m.ToEqs(st, posts), md)), md) by {
+            assert m'.ToEqs(st, posts.UpdateHead(Omni.SeqWP(ss[1..], posts, md))).Leq(
+              m.ToEqs(st, posts).UpdateHead(Omni.SeqWP(ss[1..], m.ToEqs(st, posts), md))) by {
+              if 0 in m'.Keys {
+                forall i: nat | i < |posts| 
+                  ensures m'.ToEqs(st, posts.UpdateHead(Omni.SeqWP(ss[1..], posts, md)))[i] <=
+                        m.ToEqs(st, posts).UpdateHead(Omni.SeqWP(ss[1..], m.ToEqs(st, posts), md))[i]
+                {
+                  forall st': State | st' in m'.ToEqs(st, posts.UpdateHead(Omni.SeqWP(ss[1..], posts, md)))[i] 
+                    ensures st' in m.ToEqs(st, posts).UpdateHead(Omni.SeqWP(ss[1..], m.ToEqs(st, posts), md))[i]
+                  {
+                    if i == 0 {
+                      assert forall j: Variable :: j in st'.Keys && !(j in m'.Get(0)) ==> st[j] == st'[j];
+                      SeqProcess'Correct(ss[1..], st', m'', posts, md);
+                      Omni.SeqSemCons(ss[1..], st', m''.ToEqs(st', posts), m'.SeqMerge(m'').ToEqs(st, posts), md) by {
+                        forall i: nat | i < |posts| 
+                          ensures m''.ToEqs(st', posts)[i] <= m'.SeqMerge(m'').ToEqs(st, posts)[i]
+                        {
+                          forall st'': State | st'' in m''.ToEqs(st', posts)[i]
+                            ensures st'' in m'.SeqMerge(m'').ToEqs(st, posts)[i] {
+                            if i in m''.Keys {
+                              m'.SeqMergeKeys(m'');
+                              forall j: Variable | j in st''.Keys && !(j in m'.SeqMerge(m'').Get(i))
+                                ensures st[j] == st''[j] {
+                                calc {
+                                  st[j];
+                                == { if j in m'.Get(0) { m'.SeqMergeGet1(m'', j, i); } }
+                                  st'[j];
+                                == { if j in m''.Get(i) { m'.SeqMergeGet2(m'', j, i); } }
+                                  st''[j];
+                                }
+                              }
+                            } 
+                          }
+                        }
+                      }
+                      assert Omni.SeqSem(ss[1..], st', m.ToEqs(st, posts), md);
+                    } else {
+                      assert st' in m'.SeqMerge(m'').ToEqs(st, posts)[i] by {
+                        if i in m'.Keys {
+                          m'.SeqMergeKeys(m'');
+                          forall j: Variable | j in st'.Keys && !(j in m'.SeqMerge(m'').Get(i))
+                            ensures st[j] == st'[j] {
+                            if j in m'.Get(i) {
+                              m'.SeqMergeGet1'(m'', j, i);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  function Process(stmt: Stmt): set<Variable> 
+    requires stmt.ValidCalls()
+    ensures forall v <- Process(stmt) :: v in stmt.FVars()
+  {
+    var vs := Process'(stmt);
+    if 0 in vs.Keys then vs[0] else {}
+  } 
+
+  lemma Correct'(stmt: Stmt, st: State, vars: set<Variable>, posts: Omni.Continuation, md: M.Model) 
+    requires stmt.ValidCalls()
+    requires forall v <- vars :: v in st.Keys
+    requires Omni.Sem(stmt, st, posts, md)
+    requires Process(stmt) == vars
+    ensures Omni.Sem(stmt, st, posts.UpdateHead(posts.head * st.EqExcept(vars)), md)
+  {
+    Process'Correct(stmt, st, Process'(stmt), posts, md);
+    Omni.SemCons(stmt, st, Process'(stmt).ToEqs(st, posts), posts.UpdateHead(posts.head * st.EqExcept(vars)), md);
+  }
+
+  lemma Correct(stmt: Stmt, st: State, st': State, vars: set<Variable>, posts: Omni.Continuation, post: iset<State>, md: M.Model) 
+    requires stmt.ValidCalls()
+    requires forall v <- vars :: v in st.Keys
+    requires Omni.Sem(stmt, st, posts.UpdateHead(post), md)
+    requires Process(stmt) == vars
+    requires st in st'.EqExcept(vars)
+    ensures Omni.Sem(stmt, st, posts.UpdateHead(post * st'.EqExcept(vars)), md)
+  {
+    Correct'(stmt, st, vars, posts.UpdateHead(post), md);
+    assert posts.UpdateHead(post).UpdateHead(posts.UpdateHead(post).head * st.EqExcept(vars)) == posts.UpdateHead(post * st.EqExcept(vars));
+    Omni.SemCons(stmt, st, posts.UpdateHead(post * st.EqExcept(vars)), posts.UpdateHead(post * st'.EqExcept(vars)), md);
+  }
+}

--- a/src/Sound/VCGen/BlockContinuation.dfy
+++ b/src/Sound/VCGen/BlockContinuation.dfy
@@ -1,0 +1,300 @@
+module Block {
+  import opened Utils
+  import M = Model
+  import opened Expr
+  import opened AST
+  import opened State
+
+  datatype Point = Point(cont: seq<Stmt>, varsInScope: set<Variable>)
+
+  newtype Continuation = seq<Point> {
+
+    ghost predicate IsSafe(md: M.Model) {
+      forall p <- this :: SeqIsSafe(p.cont, md)
+    }
+
+    predicate ValidCalls() {
+      forall p <- this :: SeqValidCalls(p.cont)
+    }
+
+    ghost opaque predicate VariablesDistinct(vars: set<Variable>) {
+      if this == [] then true else
+        && this[0].varsInScope <= vars
+        && SeqVariablesDistinct(this[0].cont, vars - this[0].varsInScope) 
+        && this[0].varsInScope !! this[1..].AllVarsInScope()
+        && this[1..].VariablesDistinct(vars - this[0].varsInScope)
+        // this[0].varsInScope !! vars && this[1..].VariablesDistinct(vars, this[0].varsInScope + bvars)
+    }
+
+
+    function FunctionsCalled(): set<Function> {
+      if this == [] then {} else SeqFunctionsCalled(this[0].cont) + this[1..].FunctionsCalled()
+    }
+
+    lemma FunctionsCalledSuffix(l: nat)
+      requires l < |this|
+      ensures this[l..].FunctionsCalled() <= FunctionsCalled()
+    {
+      if l != 0 {
+        assert this[l..] == [this[l]] + this[l + 1..];
+        // TODO: Might be a soundness bug
+        FunctionsCalledSuffix(l - 1);
+      }
+    }
+
+    function Update(cont: seq<Stmt>, varsInScope: set<Variable>): Continuation {
+      [Point(cont, varsInScope as set<Variable>)] + this
+    }
+
+    function VarsInScope(l: nat): set<Variable> 
+      requires l <= |this|
+    {
+      if l == 0 then {} else this[0].varsInScope + this[1..].VarsInScope(l - 1)
+    }
+
+    function AllVarsInScope(): set<Variable> {
+      if this == [] then {} else this[0].varsInScope + this[1..].AllVarsInScope()
+    }
+
+    lemma VarsInScopeLeqAll(l: nat)
+      requires l <= |this|
+      ensures VarsInScope(l) + this[l..].AllVarsInScope() == AllVarsInScope()
+    {
+
+    }
+
+    lemma VarsInScopeSuffix(l: nat)
+      requires l <= |this|
+      ensures VarsInScope(l) == this[..l].AllVarsInScope()
+    {
+      if l != 0 {
+        calc {
+          VarsInScope(l);
+        ==
+          this[0].varsInScope + this[1..].VarsInScope(l - 1);
+        == { this[1..].VarsInScopeSuffix(l - 1);
+             assert this[1..][..l - 1] == this[1..l]; }
+          this[0].varsInScope + this[1..l].AllVarsInScope();
+        == { assert this[..l][1..] == this[1..l]; }
+          this[..l].AllVarsInScope();
+        }
+
+      }
+    }
+
+    function Size(): nat {
+      if this == [] then 0 else SeqSize(this[0].cont) + 1 + this[1..].Size()
+    }
+
+    lemma UpdateSize(cont: seq<Stmt>, varsInScope: set<Variable>)
+      ensures Update(cont, varsInScope).Size() == SeqSize(cont) + Size() + 1
+    {
+
+    }
+
+    lemma SizePrefix(l: nat)
+      requires l <= |this|
+      ensures this[l..].Size() <= Size()
+    {
+      assert this[..l] + this[l..] == this;
+      SizeConcat(this[..l], this[l..]);
+    }
+
+    predicate IsDefinedOn(d: set<Variable>) {
+      AllVarsInScope() <= d
+    }
+
+    predicate JumpsDefined() {
+      if this == [] then true else
+        SeqJumpsDefinedOn(this[0].cont, |this[1..]|) && this[1..].JumpsDefined()
+    }
+
+    predicate VarsDefined(vars: set<Variable>) 
+      requires ValidCalls()
+      // requires IsDefinedOn(vars)
+    {
+      if this == [] then true else
+        && SeqIsDefinedOn(this[0].cont, vars - this[0].varsInScope) 
+        && this[1..].VarsDefined(vars - this[0].varsInScope)
+    }
+
+    lemma VarsDefinedTransitivity(vars1: set<Variable>, vars2: set<Variable>)
+      requires ValidCalls()
+      // requires IsDefinedOn(vars1)
+      requires VarsDefined(vars1)
+      requires vars1 <= vars2
+      ensures VarsDefined(vars2)
+    {
+      if this != [] {
+        this[1..].VarsDefinedTransitivity(vars1 - this[0].varsInScope, vars2 - this[0].varsInScope);
+      }
+    }
+
+    lemma AllVarsInScopeSuffixSucc(l: nat)
+      requires l < |this|
+      ensures this[..l + 1].AllVarsInScope() == this[..l].AllVarsInScope() + this[l].varsInScope
+      // ensures AllVarsInScope() == this[..l + 1].AllVarsInScope()
+    {
+      calc {
+        this[..l + 1].AllVarsInScope();
+        == { this[..l + 1].VarsInScopeLeqAll(l); }
+        this[..l + 1][l..].AllVarsInScope() + this[..l + 1].VarsInScope(l);
+        == { assert this[..l + 1][l..] == [this[l]]; }
+        this[l].varsInScope + this[..l + 1].VarsInScope(l);
+        == { this[..l + 1].VarsInScopeSuffix(l); }
+        this[l].varsInScope + this[..l + 1][..l].AllVarsInScope();
+        == { assert this[..l + 1][..l] == this[..l]; }
+        this[..l].AllVarsInScope() + this[l].varsInScope;
+      }
+    }
+
+    // lemma DefinedPrefix''(l: nat, vars: set<Variable>)
+    //   requires l <= |this|
+    //   requires ValidCalls()
+    //   // requires IsDefinedOn(vars)
+    //   ensures this[..l].AllVarsInScope() <= vars
+    // {
+    //   VarsInScopeSuffix(l);
+    //   VarsInScopeLeqAll(l);
+    // }
+
+    lemma VariablesDistinctPrefix(vars: set<Variable>, l: nat)
+      requires l <= |this|
+      requires VariablesDistinct(vars)
+      requires IsDefinedOn(vars)
+      ensures this[l..].VariablesDistinct(vars - VarsInScope(l))
+      ensures this[l..].AllVarsInScope() <= vars - VarsInScope(l)
+    {
+      if this != [] && l != 0 {
+        calc {
+          VariablesDistinct(vars);
+          ==> { reveal VariablesDistinct; }
+          && this[1..].VariablesDistinct(vars - this[0].varsInScope)
+          && this[0].varsInScope <= vars;
+          ==> { VariablesDistinctDisjoint(vars, 0);
+                this[1..].VariablesDistinctPrefix(vars - this[0].varsInScope, l - 1); }
+          && this[l..].VariablesDistinct(vars - this[0].varsInScope - this[1..].VarsInScope(l-1))
+          && this[l..].AllVarsInScope() <= vars - this[0].varsInScope - this[1..].VarsInScope(l-1);
+          == { assert vars - this[0].varsInScope - this[1..].VarsInScope(l-1) == 
+                      vars - (this[0].varsInScope + this[1..].VarsInScope(l-1)); }
+          && this[l..].VariablesDistinct(vars - VarsInScope(l))
+          && this[l..].AllVarsInScope() <= vars - VarsInScope(l);
+        }
+      } else {
+        assert vars - {} == vars;
+      }
+    }
+
+    lemma VariablesDistinctDisjoint(vars: set<Variable>, l: nat)
+      requires |this| > l
+      requires VariablesDistinct(vars)
+      ensures this[l].varsInScope !! this[l + 1..].AllVarsInScope()
+      ensures SeqVariablesDistinct(this[l].cont, vars - VarsInScope(l + 1))
+    {
+      if l != 0 {
+        calc {
+          VariablesDistinct(vars);
+          ==> { reveal VariablesDistinct; }
+          && this[1..].VariablesDistinct(vars - this[0].varsInScope);
+          ==> { this[1..].VariablesDistinctDisjoint(vars - this[0].varsInScope, l - 1); }
+          && this[l].varsInScope !! this[l+1..].AllVarsInScope()
+          && SeqVariablesDistinct(this[l].cont, vars - this[0].varsInScope - this[1..].VarsInScope(l));
+          == { assert vars - this[0].varsInScope - this[1..].VarsInScope(l) == 
+                      vars - (this[0].varsInScope + this[1..].VarsInScope(l)); }
+          && this[l].varsInScope !! this[l+1..].AllVarsInScope()
+          && SeqVariablesDistinct(this[l].cont, vars - VarsInScope(l + 1));
+        }
+      } else {
+        reveal VariablesDistinct;
+        assert VarsInScope(1) == this[0].varsInScope;
+      }
+    }
+
+    lemma DefinedPrefix'(l: nat, vars: set<Variable>)
+      requires l < |this|
+      requires ValidCalls()
+      requires JumpsDefined()
+      // requires VariablesDistinct(bvars)
+      // requires IsDefinedOn(vars)
+      requires VarsDefined(vars)
+      ensures SeqJumpsDefinedOn(this[l].cont, |this[l + 1..]|) 
+      // ensures this[..l + 1].AllVarsInScope() <= vars
+      ensures SeqIsDefinedOn(this[l].cont, vars - this[..l + 1].AllVarsInScope())
+      // ensures SeqIsDefinedOn(this[l].cont, 1000) /*SOUNDNESS BUG:*/
+    {
+      // DefinedPrefix''(l + 1, vars);
+      if this != [] {
+        if l != 0 {
+          assert this[1..][l - 1] == this[l];
+          assert this[1..][l - 1..] == this[l..];
+          assert this[1..][..l] == this[1..l + 1];
+          this[1..].DefinedPrefix'(l - 1, vars - this[0].varsInScope);
+          assert SeqIsDefinedOn(this[l].cont, vars - this[0].varsInScope - this[1..l + 1].AllVarsInScope());
+          assert SeqIsDefinedOn(this[l].cont, vars - this[..l + 1].AllVarsInScope());
+        }
+      }
+    }
+
+    lemma DefinedPrefix(l: nat, vars: set<Variable>)
+      requires l <= |this|
+      requires ValidCalls()
+      requires JumpsDefined()
+      // requires IsDefinedOn(vars)
+      requires VarsDefined(vars)
+      ensures this[l..].JumpsDefined()
+      // ensures this[..l].AllVarsInScope() <= vars
+      // ensures this[l..].IsDefinedOn(vars - this[..l].AllVarsInScope())
+      ensures this[l..].VarsDefined(vars - this[..l].AllVarsInScope())
+      decreases |this| - l
+    {
+      if l != 0 {
+        if |this| != l {
+          assert this[l + 1..] == this[l..][1..];
+          assert this[1..][..l - 1] == this[1..l];
+          assert this[1..][..l] == this[1..l + 1];
+          assert this[l..][0] == this[l];
+          DefinedPrefix(l + 1, vars);
+          DefinedPrefix'(l, vars);
+          // assert this[..l+1].AllVarsInScope() <= vars;
+          assert this[..l+1].AllVarsInScope() == this[..l].AllVarsInScope() + this[l].varsInScope by {
+            AllVarsInScopeSuffixSucc(l);
+          }
+          // calc {
+          //   this[l..].IsDefinedOn(vars - this[..l].AllVarsInScope());
+          //   { VarsInScopeLeqAll(l + 1); }
+          //   SeqIsDefinedOn(this[l].cont, vars - this[..l].AllVarsInScope()) && 
+          //     this[l+1..].IsDefinedOn(vars - this[..l].AllVarsInScope() - this[l].varsInScope);
+          //   true;
+          // }
+          var m := vars - this[..l].AllVarsInScope();
+          calc {
+            this[l..].VarsDefined(m);
+            { assert m - this[l].varsInScope == vars - this[..l + 1].AllVarsInScope(); }
+            SeqIsDefinedOn(this[l].cont, vars - this[..l + 1].AllVarsInScope()) && 
+            this[l + 1..].VarsDefined(vars - this[..l + 1].AllVarsInScope());
+            SeqIsDefinedOn(this[l].cont, vars - this[..l + 1].AllVarsInScope());
+            true;
+          }
+        } else {
+          VarsInScopeLeqAll(|this|);
+          VarsInScopeSuffix(|this|);
+        }
+      } else {
+        assert vars - this[..0].AllVarsInScope() == vars;
+      }
+    }
+  }
+
+    lemma SizeConcat(cont1: Continuation, cont2: Continuation)
+      ensures (cont1 + cont2).Size() == cont1.Size() + cont2.Size()
+    {
+      if cont1 == [] {
+        assert cont1 + cont2 == cont2;
+      } else {
+        assert (cont1 + cont2)[0] == cont1[0];
+        assert (cont1 + cont2)[1..] == cont1[1..] + cont2;
+        SizeConcat(cont1[1..], cont2);
+      }
+    }
+
+}

--- a/src/Sound/VCGen/Context.dfy
+++ b/src/Sound/VCGen/Context.dfy
@@ -1,0 +1,515 @@
+module Context {
+  import opened Utils
+  import M = Model
+  import opened AST
+  import opened State
+  import opened Expr
+
+  datatype Context = Context(
+    ctx: seq<Expr>,
+    incarnation: map<Variable, Variable>) 
+  {
+    ghost function Models(md: M.Model) : iset<State> { iset st: State | IsSatisfiedOn(st, md) }
+
+    ghost function AdjustedModels(md: M.Model) : iset<State> { 
+      iset st: State | exists st' <- Models(md) {:InAdjustedModelsLemma(st', md)} :: AdjustState(st') == st
+    }
+
+    lemma InAdjustedModelsLemma(st: State, st': State, md: M.Model)
+//       requires IsSatisfiedOn(st', md)
+//       requires st == AdjustState(st')
+//       ensures st in AdjustedModels(md)
+//     {
+
+//     }
+
+    function FVars(): set<Variable> 
+    {
+      SeqExprFVars(ctx) + incarnation.Values
+    }
+
+    function FreshVarSet(typ: Type, vars: set<Variable>): Variable
+      ensures FreshVarSet(typ, vars) !in incarnation.Values
+      ensures FreshVarSet(typ, vars) !in SeqExprFVars(ctx)
+      ensures FreshVarSet(typ, vars) !in vars
+      ensures forall c <- ctx :: FreshVarSet(typ, vars) !in c.FVars()
+      ensures FreshVarSet(typ, vars).typ == typ
+
+    function FreshVar(typ: Type): Variable
+      ensures FreshVar(typ) !in incarnation.Values
+      ensures FreshVar(typ) !in SeqExprFVars(ctx)
+      ensures forall c <- ctx :: FreshVar(typ) !in c.FVars()
+      ensures FreshVar(typ).typ == typ
+    {
+      FreshVarSet(typ, {})
+    }
+
+    function AdjustState(s: State): State
+      requires incarnation.Values <= s.Keys
+    {
+      map v | v in incarnation.Keys :: s[incarnation[v]]
+    }
+
+    function AdjustStateBVars(s: State, bVars: set<Variable>): State
+      requires incarnation.Values <= s.Keys + bVars
+    {
+      map v | v in incarnation.Keys && incarnation[v] !in bVars :: 
+        s[incarnation[v]]
+    }
+
+    function UpdateIncarnation(v: Variable, x: Variable): Context
+    {
+      Context(ctx, incarnation[v := x])
+    }
+
+    /*
+      incr = map[u -> v]
+
+      let v := .. in v + u
+    */
+
+    function Substitute(e: Expr): Expr
+      requires e.IsDefinedOn(incarnation.Keys)
+      decreases e
+    {
+      match e
+      case BConst(bvalue) => e
+      case IConst(ivalue) => e
+      case CustomConst(value) => e
+      case BVar(v) => BVar(incarnation[v])
+      case OperatorExpr(op, args) => OperatorExpr(op, SeqSubstitute(args))
+      case FunctionCallExpr(func, args) => FunctionCallExpr(func, SeqSubstitute(args))
+      case LetExpr(v, rhs, body) => 
+        var v' := v.FreshVar(incarnation.Values);
+        LetExpr(v', Substitute(rhs), UpdateIncarnation(v, v').Substitute(body))
+      case QuantifierExpr(univ, v, body) => 
+        var v' := v.FreshVar(incarnation.Values);
+        QuantifierExpr(univ, v', UpdateIncarnation(v, v').Substitute(body))
+    }
+
+    function SeqSubstitute(ss: seq<Expr>): seq<Expr>
+      requires SeqExprFVars(ss) <= incarnation.Keys
+      ensures |SeqSubstitute(ss)| == |ss|
+      decreases ss
+    {
+      if ss == [] then [] else
+      [Substitute(ss[0])] + SeqSubstitute(ss[1..])
+    }
+
+    function MkEntailment(e: Expr): Expr
+      requires e.IsDefinedOn(incarnation.Keys)
+    {
+      Implies(Conj(ctx), Substitute(e))
+    }
+
+    function MkEntailmentSeq(ss: seq<Expr>): seq<Expr>
+      requires SeqExprFVars(ss) <= incarnation.Keys
+    {
+      seq(|ss|, (i: nat) requires i < |ss| => 
+        SeqExprFVarsLemma(ss, ss[i]);
+        MkEntailment(ss[i]))
+    }
+
+    lemma MkEntailmentSeqLemma(ss: seq<Expr>, e: Expr)
+      requires SeqExprFVars(ss) <= incarnation.Keys
+      requires e in ss
+      ensures forall e <- ss :: e.IsDefinedOn(incarnation.Keys)
+      ensures MkEntailment(e) in MkEntailmentSeq(ss)
+    {
+      forall e <- ss { SeqExprFVarsLemma(ss, e); }
+      assert MkEntailment(e) == MkEntailmentSeq(ss)[Index(ss, e)];
+    }
+
+    ghost predicate IsDefinedOn(d: set<Variable>)
+    {
+      forall e <- ctx :: e.IsDefinedOn(d)
+    }
+
+    /*
+    
+    */
+    ghost predicate IsSatisfiedOn(s: State, md: M.Model) 
+    {
+      && IsDefinedOn(s.Keys)
+      && incarnation.Values <= s.Keys
+      && (forall e <- ctx :: e.HoldsOn(s, md))
+    }
+
+    lemma  SubstituteIsDefinedOnLemma(e: Expr, d: set<Variable>)
+      requires e.IsDefinedOn(incarnation.Keys)
+      requires incarnation.Values <= d
+      ensures Substitute(e).IsDefinedOn(d)
+      decreases e
+    {
+      match e
+      case BVar(v) => 
+        if v in incarnation.Keys { assert incarnation[v] in incarnation.Values; }
+      case OperatorExpr(op, args) =>
+        SeqSubstituteIsDefinedOnLemma(args, d);
+      case FunctionCallExpr(func, args) =>
+        SeqSubstituteIsDefinedOnLemma(args, d);
+      case LetExpr(v, rhs, body) =>
+        var v' := v.FreshVar(incarnation.Values);
+        calc {
+          Substitute(e).FVars();
+          == 
+          Substitute(rhs).FVars() + (UpdateIncarnation(v, v').Substitute(body).FVars() - {v'});
+          <= { UpdateIncarnation(v, v').SubstituteIsDefinedOnLemma(body, d + {v'}); }
+          d + (d + {v'} - {v'});
+        }
+      case QuantifierExpr(univ, v, body) =>
+        var v' := v.FreshVar(incarnation.Values);
+        calc {
+          Substitute(e).FVars();
+          == 
+          UpdateIncarnation(v, v').Substitute(body).FVars() - {v'};
+          <= { UpdateIncarnation(v, v').SubstituteIsDefinedOnLemma(body, d + {v'}); }
+          d;
+        }
+      case _ =>
+    }
+
+    lemma SeqSubstituteIsDefinedOnLemma(ss: seq<Expr>, d: set<Variable>)
+      requires SeqExprFVars(ss) <= incarnation.Keys
+      requires incarnation.Values <= d
+      ensures forall e <- SeqSubstitute(ss) :: e.IsDefinedOn(d)
+      ensures SeqExprFVars(SeqSubstitute(ss)) <= d
+      decreases ss
+    {
+      if ss != [] {
+        SubstituteIsDefinedOnLemma(ss[0], d);
+        SeqSubstituteIsDefinedOnLemma(ss[1..], d);
+      }
+    }
+
+    lemma ForallPush(s1: State, s2: State, e1: Expr, e2: Expr, v: Variable, md: M.Model)
+      requires e1.IsDefinedOn(s1.Keys + {v})
+      requires e2.IsDefinedOn(s2.Keys + {v})
+      requires forall b: M.Any | md.HasType(b, v.typ.ToType()) :: e1.Eval(s1.UpdateAt(v, b), md) == e2.Eval(s2.UpdateAt(v, b), md)
+      ensures (forall b: M.Any | md.HasType(b, v.typ.ToType()) :: e1.HoldsOn(s1.UpdateAt(v, b), md)) == (forall b: M.Any | md.HasType(b, v.typ.ToType()) :: e2.HoldsOn(s2.UpdateAt(v, b), md))
+      ensures (forall b: M.Any | md.HasType(b, v.typ.ToType()) :: SomeBVal?(e1.Eval(s1.UpdateAt(v, b), md), md)) == (forall b: M.Any | md.HasType(b, v.typ.ToType()) :: SomeBVal?(e2.Eval(s2.UpdateAt(v, b), md), md))
+    {  }
+
+    lemma ExistsPush(s1: State, s2: State, e1: Expr, e2: Expr, v: Variable, md: M.Model)
+      requires e1.IsDefinedOn(s1.Keys + {v})
+      requires e2.IsDefinedOn(s2.Keys + {v})
+      requires forall b: M.Any | md.HasType(b, v.typ.ToType()) :: e1.HoldsOn(s1.UpdateAt(v, b), md) == e2.HoldsOn(s2.UpdateAt(v, b), md)
+      ensures (exists b: M.Any | md.HasType(b, v.typ.ToType()) :: e1.HoldsOn(s1.UpdateAt(v, b), md)) == (exists b: M.Any | md.HasType(b, v.typ.ToType()) :: e2.HoldsOn(s2.UpdateAt(v, b), md))
+    {  }
+
+    lemma SeqAdjustStateSubstituteLemma(ss: seq<Expr>, s: State, md: M.Model)
+      requires SeqExprFVars(ss) <= incarnation.Keys
+      requires incarnation.Values <= s.Keys
+      ensures
+        (SeqSubstituteIsDefinedOnLemma(ss, s.Keys);
+         SeqEval(ss, AdjustState(s), md) == 
+         SeqEval(SeqSubstitute(ss), s, md))
+      decreases ss
+    {
+      if ss != [] {
+        SeqAdjustStateSubstituteLemma(ss[1..], s, md);
+        SeqSubstituteIsDefinedOnLemma(ss, s.Keys);
+        AdjustStateSubstituteLemma(s, ss[0], md);
+      }
+    }
+
+
+    lemma AdjustStateSubstituteLemma(s: State, e: Expr, md: M.Model)
+      requires e.IsDefinedOn(incarnation.Keys)
+      requires incarnation.Values <= s.Keys
+      ensures (SubstituteIsDefinedOnLemma(e, s.Keys);
+        e.Eval(AdjustState(s), md)) == Substitute(e).Eval(s, md)
+      decreases e
+    {
+      match e
+      case OperatorExpr(op, args) =>
+        SeqAdjustStateSubstituteLemma(args, s, md);
+      case FunctionCallExpr(func, args) =>
+        SeqAdjustStateSubstituteLemma(args, s, md);
+      case QuantifierExpr(univ, v, body) => 
+        var v' := v.FreshVar(incarnation.Values);
+        SubstituteIsDefinedOnLemma(e, s.Keys);
+        forall b: M.Any | md.HasType(b, v.typ.ToType()) 
+          ensures body.Eval(AdjustState(s).UpdateAt(v, b), md) == UpdateIncarnation(v, v').Substitute(body).Eval(s.UpdateAt(v', b), md) {
+          calc {
+            UpdateIncarnation(v, v').Substitute(body).Eval(s.UpdateAt(v', b), md);
+            == { UpdateIncarnation(v, v').AdjustStateSubstituteLemma(s.UpdateAt(v', b), body, md); }
+            body.Eval(UpdateIncarnation(v, v').AdjustState(s.UpdateAt(v', b)), md);
+            == { body.EvalFVarsLemma(AdjustState(s).UpdateAt(v, b), UpdateIncarnation(v, v').AdjustState(s.UpdateAt(v', b)), md); }
+            body.Eval(AdjustState(s).UpdateAt(v, b), md);
+          }
+        }
+      case BVar(v) => if v in incarnation.Keys { assert incarnation[v] in incarnation.Values; }
+      case LetExpr(v, rhs, body) =>
+        var v' := v.FreshVar(incarnation.Values);
+        var b := Substitute(rhs).Eval(s, md) by {
+          SubstituteIsDefinedOnLemma(rhs, s.Keys);
+        }
+        if b.Some? {
+          var b := b.value;
+          SubstituteIsDefinedOnLemma(e, s.Keys);
+          calc {
+            Substitute(e).Eval(s, md);
+            ==
+            LetExpr(v', Substitute(rhs), UpdateIncarnation(v, v').Substitute(body)).Eval(s, md);
+            ==
+            UpdateIncarnation(v, v').Substitute(body).Eval(s.UpdateAt(v', b), md);
+            == { UpdateIncarnation(v, v').AdjustStateSubstituteLemma(s.UpdateAt(v', b), body, md); }
+            body.Eval(UpdateIncarnation(v, v').AdjustState(s.UpdateAt(v', b)), md);
+            == { body.EvalFVarsLemma(AdjustState(s).UpdateAt(v, b), UpdateIncarnation(v, v').AdjustState(s.UpdateAt(v', b)), md); }
+            body.Eval(AdjustState(s).UpdateAt(v, b), md);
+          }
+        }
+      case _  => 
+    }
+
+//     lemma AdjustStateSubstituteLemma(s: State, e: Expr, md: M.Model)
+//       requires e.IsDefinedOn(|incarnation|)
+//       requires forall ic <- incarnation :: ic < |s|
+//       ensures Substitute(e).IsDefinedOn(|s|)
+//       ensures e.HoldsOn(AdjustState(s), md) == Substitute(e).HoldsOn(s, md)
+//     {
+//       SubstituteIsDefinedOnLemma(e, |s|);
+//       AdjustStateSubstituteIdxLemma(s, e, 0, md);
+//       assert [] + AdjustState(s) == AdjustState(s);
+//     }
+//   }
+
+    lemma MkEntailmentLemma(e: Expr, st: State, md: M.Model)
+      requires e.IsDefinedOn(incarnation.Keys)
+      requires incarnation.Values <= st.Keys
+      requires IsSatisfiedOn(st, md)
+      requires MkEntailment(e).Holds(md)
+      ensures e.HoldsOn(AdjustState(st), md)
+    {
+      assert Implies(Conj(ctx), Substitute(e)).IsDefinedOn(st.Keys) by {
+        IsDefinedOnImpliesLemma(Conj(ctx), Substitute(e), st) by {
+          EvalConjLemma(ctx, st, md);
+          SubstituteIsDefinedOnLemma(e, st.Keys);
+        }
+      }
+      assert e.HoldsOn(AdjustState(st), md) by { 
+        calc {
+          e.HoldsOn(AdjustState(st), md);
+          { SubstituteIsDefinedOnLemma(e, st.Keys);
+            AdjustStateSubstituteLemma(st, e, md); }
+          Substitute(e).HoldsOn(st, md);
+          { EvalConjLemma(ctx, st, md);
+            AdjustStateSubstituteLemma(st, e, md);
+            HoldsOnImpliesLemma(Conj(ctx), Substitute(e), st, md); }
+          MkEntailment(e).Holds(md);
+        }
+      }
+    }
+
+    function Add(e: Expr): Context
+      requires e.IsDefinedOn(incarnation.Keys)
+    {
+      this.(ctx := ctx + [Substitute(e)])
+    }
+
+//     function SeqSubstitute(ss: seq<Expr>): seq<Expr>
+//       requires forall e <- ss :: e.IsDefinedOn(|incarnation|)
+//     {
+//       seq(|ss|, (i: nat) requires i < |ss| => Substitute(ss[i]))
+//     }
+
+    lemma GetSeqSubstituteLemma(ss: seq<Expr>, e: Expr) returns (e': Expr) 
+      requires SeqExprFVars(ss) <= incarnation.Keys
+      requires e in SeqSubstitute(ss)
+      ensures e' in ss
+      ensures e'.IsDefinedOn(incarnation.Keys)
+      ensures Substitute(e') == e
+    {
+      if ss != [] {
+        if Substitute(ss[0]) == e {
+          e' := ss[0];
+        } else {
+          e' := GetSeqSubstituteLemma(ss[1..], e);
+        }
+      }
+    }
+
+    function AddSeq(ss: seq<Expr>): Context
+      requires SeqExprFVars(ss) <= incarnation.Keys
+    {
+      this.(ctx := ctx + SeqSubstitute(ss))
+    }
+
+    function mkPreContext(proc: Procedure, args: CallArguments): Context
+      requires Call(proc, args).ValidCalls()
+      requires args.IsDefinedOn(incarnation.Keys)
+      ensures mkPreContext(proc, args).incarnation.Keys == args.FVars()
+      ensures forall i <- mkPreContext(proc, args).incarnation.Values :: i in incarnation.Values
+    {
+      var incrPre := map v | v in args.FVars() :: incarnation[v];
+      Context(ctx, incrPre)
+    }
+
+    lemma mkPreContextLemma(proc: Procedure, args: CallArguments, s: State)
+      requires Call(proc, args).ValidCalls()
+      requires args.IsDefinedOn(incarnation.Keys)
+      requires incarnation.Values <= s.Keys
+      ensures mkPreContext(proc, args).AdjustState(s) == args.Eval(AdjustState(s))
+    {
+      forall v | v in args.FVars()
+        ensures (mkPreContext(proc, args).AdjustState(s))[v] == args.Eval(AdjustState(s))[v]
+      {
+        assert incarnation[v] in incarnation.Values;
+        assert s[incarnation[v]] == args.Eval(AdjustState(s))[v];
+      }
+    }
+
+    function mkPostContext(proc: Procedure, args: CallArguments/*, oldContext: Context*/): Context
+      requires Call(proc, args).ValidCalls()
+      requires args.IsDefinedOn(incarnation.Keys)
+      // requires args.IsDefinedOn(oldContext.incarnation.Keys)
+      // requires |oldContext.incarnation| >= args.NumInOutArgs()
+      ensures mkPostContext(proc, args/*, oldContext*/).incarnation.Keys == args.FVars() /*+ args.NumInOutArgs()*/
+    {
+      // var oldNum := args.NumInOutArgs();
+      var incrPost: map<Variable, Variable> := map v | v in args.FVars() :: incarnation[v];
+      // var incrPostOld: seq<Idx> := seq(args.NumInOutArgs(), (i: nat) requires i < args.NumInOutArgs() => 
+      //   args.InOutArgsLemma(args.InOutArgs()[i]); 
+      //   args.IsDefinedOnIn(InOutArgument(args.InOutArgs()[i]), |oldContext.incarnation|);
+      //   oldContext.incarnation[args.InOutArgs()[i]]);
+      Context(ctx, incrPost /*+ incrPostOld*/)
+    }
+
+    lemma mkPostContextIncrSubsetLemma(proc: Procedure, args: CallArguments,/* oldContext: Context,*/ v: Variable)
+      requires Call(proc, args).ValidCalls()
+      requires args.IsDefinedOn(incarnation.Keys)
+      // requires args.IsDefinedOn(|oldContext.incarnation|)
+      // requires |oldContext.incarnation| >= args.NumInOutArgs()
+      requires v in mkPostContext(proc, args/*, oldContext*/).incarnation.Values
+      ensures /*i in oldContext.incarnation ||*/ v in incarnation.Values
+    {
+      // var oldNum := args.NumInOutArgs();
+      // var incrPost: seq<Idx> := seq(|args|, (i: nat) requires i < |args| => 
+      //   args.IsDefinedOnIn(args[i], |incarnation|);
+      //   incarnation[args[i].v]); 
+      // var incrPostOld: seq<Idx> := seq(args.NumInOutArgs(), (i: nat) requires i < args.NumInOutArgs() => 
+      //   args.InOutArgsLemma(args.InOutArgs()[i]); 
+      //   args.IsDefinedOnIn(InOutArgument(args.InOutArgs()[i]), |oldContext.incarnation|);
+      //   oldContext.incarnation[args.InOutArgs()[i]]);
+      // assert incrPost + incrPostOld == mkPostContext(proc, args, oldContext).incarnation;
+      // assert i in incrPost + incrPostOld;
+      // if i in incrPost {
+      //   assert i == incrPost[Index(incrPost, i)];
+      //   args.IsDefinedOnIn(args[Index(incrPost, i)], |incarnation|);
+      //   assert i == incarnation[args[Index(incrPost, i)].v];
+      // } else {
+      //   assert i in incrPostOld;
+      //   assert i == incrPostOld[Index(incrPostOld, i)];
+      //   args.InOutArgsLemma(args.InOutArgs()[Index(incrPostOld, i)]);
+      //   args.IsDefinedOnIn(InOutArgument(args.InOutArgs()[Index(incrPostOld, i)]), |oldContext.incarnation|);
+      //   assert i == oldContext.incarnation[args.InOutArgs()[Index(incrPostOld, i)]];
+      // }
+    }
+
+    method AddEq(v: Variable, e: Expr) returns (ghost vNew: Variable, context: Context)
+      requires v in incarnation.Keys
+      requires e.IsDefinedOn(incarnation.Keys)
+      ensures incarnation.Keys == context.incarnation.Keys
+      ensures ctx + [Eq(BVar(vNew), Substitute(e))] == context.ctx
+      ensures incarnation[v := vNew] == context.incarnation
+      // ensures forall i <- incarnation.Values :: i < vNew 
+      ensures forall c <- ctx :: vNew !in c.FVars()
+      ensures vNew !in incarnation.Values
+      ensures vNew !in SeqExprFVars(ctx)
+      // ensures 
+    {
+      var v' := FreshVar(v.typ);
+      var ctx' := ctx + [Eq(BVar(v'), Substitute(e))];
+      var incarnation' := incarnation[v := v'];
+      context := Context(ctx', incarnation');
+      vNew := v';
+    }
+
+    method AddVarSet(vars: set<Variable>) returns (ghost vsNew: map<Variable, Variable>, context: Context)
+      // requires vars <= incarnation.Keys
+      ensures vsNew.Values == vars
+      ensures context.ctx         == ctx
+      ensures context.incarnation.Keys == incarnation.Keys + vars
+      ensures forall v <- vars :: context.incarnation[v] in vsNew.Keys && vsNew[context.incarnation[v]] == v
+      ensures vsNew.Keys !! incarnation.Values
+      ensures forall c <- ctx :: c.FVars() !! vsNew.Keys
+      ensures SeqExprFVars(ctx) !! vsNew.Keys
+      ensures forall v <- incarnation.Keys :: v !in vars ==> context.incarnation[v] == incarnation[v]
+      ensures context.incarnation.Values <= vsNew.Keys + incarnation.Values
+    {
+      var vars' := vars; 
+      var incr' := incarnation;
+      var vs: map<Variable, Variable> := map[];
+      // vNew := v';
+      while vars' != {}
+        invariant incr'.Keys == incarnation.Keys + (vars - vars')
+        invariant vars' <= vars
+        invariant forall v <- vars - vars' :: incr'[v] in vs.Keys && vs[incr'[v]] == v
+        invariant vs.Keys !! incarnation.Values
+        invariant forall v <- incarnation.Keys :: v !in vars - vars' ==> incr'[v] == incarnation[v]
+        invariant incr'.Values <= vs.Keys + incarnation.Values
+        invariant forall c <- ctx :: c.FVars() !! vs.Keys
+        invariant SeqExprFVars(ctx) !! vs.Keys
+        invariant vs.Values == vars - vars'
+      {
+        var v :| v in vars';
+        vars' := vars' - {v};
+        var v' := FreshVarSet(v.typ, vs.Keys);
+        assert vs[v' := v].Values == vs.Values + {v} by {
+          assert vs[v' := v] == vs + map[v' := v];
+        }
+        vs := vs[v' := v];
+        incr' := incr'[v := v'];
+      }
+      vsNew := vs;
+      context := Context(ctx, incr');
+    }
+
+    function Delete(vars: set<Variable>): Context
+      requires vars <= incarnation.Keys
+    {
+      Context(ctx, incarnation - vars)
+    }
+      
+
+    // method AddVars(n: nat) returns (ghost vNew: Idx, context: Context)
+    //   // ensures incarnation <= AddVars(n).incarnation 
+    //   ensures context.ctx         == ctx
+    //   ensures |context.incarnation| == |incarnation| + n
+    //   ensures forall i: nat :: i < n ==> context.incarnation[i] == vNew + i
+    //   ensures forall i: nat :: n <= i < |incarnation| + n ==> context.incarnation[i] == incarnation[i - n]
+    //   ensures forall c <- ctx :: c.Depth() < vNew
+    //   ensures SeqMax(incarnation) < vNew
+    //   ensures SeqExprDepth(ctx) < vNew
+    // {
+    //   var v := FreshIdx();
+    //   var addOn := seq(n, (i: nat) => v + i);
+    //   context := Context(ctx, addOn + incarnation);
+    //   vNew := v;
+    // }
+
+//     // lemma SubstituteIdxIsDefinedOnLemmaOperator
+  }
+
+  function mkInitialContext(proc: Procedure): Context
+  {
+    var incr := map v | v in proc.ParametersKeys() :: v;
+    // var incrOld := seq(proc.NumInOutArgs(), (i: nat) requires i < proc.NumInOutArgs() => 
+    //   proc.InOutVarsIdxs()[i]);
+    Context(proc.Pre, incr /*+ incrOld*/)
+  }
+
+//   lemma mkInitialContextLemma(proc: Procedure, i: nat)
+//     requires i in mkInitialContext(proc).incarnation
+//     ensures i < |proc.Parameters| + proc.NumInOutArgs()
+//   {
+//     var incr := seq(|proc.Parameters|, (i: nat) => i);
+//     var incrOld := seq(proc.NumInOutArgs(), (i: nat) requires i < proc.NumInOutArgs() => 
+//       proc.InOutVarsIdxs()[i]);
+//     if i in incrOld {
+//       assert i == proc.InOutVarsIdxs()[Index(incrOld, i)];
+//       proc.InOutVarsIdxsLemma(proc.Parameters, 0, Index(incrOld, i));
+//     }
+  // }
+}

--- a/src/Sound/VCGen/Sound.dfy
+++ b/src/Sound/VCGen/Sound.dfy
@@ -1,0 +1,738 @@
+module VCGenOmni {
+  import opened Utils
+  import M = Model
+  import opened AST
+  import opened State
+  import opened Context
+  import opened Expr
+  import Block
+  import Omni
+  import AssignmentTarget
+
+  method VCGen(s: Stmt, context_in: Context) returns (context: Context, VCs: seq<Expr>) 
+    requires s.ValidCalls()
+    requires s.IsDefinedOn(context_in.incarnation.Keys)
+    requires s.Single()
+    // requires s.IsSafe()
+    ensures context_in.incarnation.Keys == context.incarnation.Keys
+    ensures forall md: M.Model :: 
+      s.IsSafe(md) ==>
+      SeqHolds(VCs, md) ==> 
+      forall st: State :: 
+        context_in.IsSatisfiedOn(st, md) ==>
+        Omni.SemSingle(s, context_in.AdjustState(st), context.AdjustedModels(md), md)
+  {
+    context := context_in;
+    match s
+    case Check(e) =>
+      VCs := [context_in.MkEntailment(e)];
+      forall md: M.Model, st: State | 
+        && SeqHolds(VCs, md)
+        && context.IsSatisfiedOn(st, md) 
+        ensures Omni.SemSingle(s, context_in.AdjustState(st), context.AdjustedModels(md), md) {
+        context.MkEntailmentLemma(e, st, md);
+      }
+    case Assume(e) => 
+      context := context_in.Add(e);
+      VCs := [];
+      forall md: M.Model, st: State | context_in.IsSatisfiedOn(st, md) 
+        ensures Omni.SemSingle(s, context_in.AdjustState(st), context.AdjustedModels(md), md) {
+        if e.HoldsOn(context.AdjustState(st), md) {
+          context_in.SubstituteIsDefinedOnLemma(e, st.Keys);
+          context_in.AdjustStateSubstituteLemma(st, e, md);
+        }
+      }
+    case Assign(v, x) =>
+      ghost var vNew;
+      vNew, context := context_in.AddEq(v, x);
+      VCs := [];
+      forall md: M.Model, st: State | context_in.IsSatisfiedOn(st, md) && s.IsSafe(md)
+        ensures Omni.SemSingle(s, context_in.AdjustState(st), context.AdjustedModels(md), md) {
+        context_in.SubstituteIsDefinedOnLemma(x, st.Keys);
+        var v' := context_in.Substitute(x).Eval(st, md);
+        assert x.Eval(context_in.AdjustState(st), md) == v' by {
+          context_in.AdjustStateSubstituteLemma(st, x, md);
+        }
+        var st' := st.UpdateAt(vNew, v'.value);
+        var stTransformed := context_in.AdjustState(st)[v := v'.value];
+
+        assert stTransformed == context.AdjustState(st') by {
+          context_in.AdjustStateSubstituteLemma(st, x, md);
+        }
+
+        assert context.IsSatisfiedOn(st', md) by {
+          // assert vNew !in 
+          context_in.SubstituteIsDefinedOnLemma(x, context_in.incarnation.Values);
+          context_in.Substitute(x).EvalFVarsLemma(st, st', md);
+          EvalEqLemma(BVar(vNew), context_in.Substitute(x), st', md);
+
+          assert forall e <- context_in.ctx :: e.HoldsOn(st, md) ==> e.HoldsOn(st', md) by 
+          {
+            forall e: Expr | e in context_in.ctx && e.HoldsOn(st, md) ensures e.HoldsOn(st', md) {
+              e.EvalFVarsLemma(st, st', md);
+            }
+          }
+        }
+      }
+    case Call(proc, args) => 
+      var contextPre := context_in.mkPreContext(proc, args);
+      VCs := seq(|proc.Pre|, (i: nat) requires i < |proc.Pre| => 
+        SeqExprFVarsLemma(proc.Pre, proc.Pre[i]);
+        contextPre.MkEntailment(proc.Pre[i]));
+      var vsNew, context' := context_in.AddVarSet(args.OutArgs()) by {
+        args.OutArgsDepthLemma();
+      }
+      var contextPost := context'.mkPostContext(proc, args/*, context_in*/);
+      context := Context(contextPost.AddSeq(proc.Post).ctx, context'.incarnation);
+
+      args.OutArgsDepthLemma();
+      forall md: M.Model, st: State | 
+        && SeqHolds(VCs, md)
+        && context_in.IsSatisfiedOn(st, md)
+        ensures Omni.SemSingle(s, context_in.AdjustState(st), context.AdjustedModels(md), md) 
+      {
+        var stAdj := context_in.AdjustState(st);
+        var callSt := args.Eval(stAdj);
+        assert args.IsDefinedOn(stAdj.Keys);
+        forall e <- proc.Pre  
+          ensures e.IsDefinedOn(callSt.Keys) 
+          ensures e.HoldsOn(callSt, md) 
+        {
+          SeqExprFVarsLemma(proc.Pre, e);
+          calc {
+            e.HoldsOn(callSt, md);
+            { context_in.mkPreContextLemma(proc, args, st); }
+            e.HoldsOn(contextPre.AdjustState(st), md);
+            { contextPre.MkEntailmentLemma(e, st, md); }
+            contextPre.MkEntailment(e).Holds(md);
+            { contextPre.MkEntailmentSeqLemma(proc.Pre, e);
+              assert contextPre.MkEntailment(e) in VCs;
+              assert forall e <- VCs :: e.Holds(md  ); }
+            true;
+          }
+        }
+        forall st': State | 
+          && st' in stAdj.EqExcept(args.OutArgs()) 
+          && st'.Keys == stAdj.Keys
+          && var callSt' := args.Eval(st') /*+ args.EvalOld(stAdj)*/;
+              forall e <- proc.Post :: e.IsDefinedOn(callSt'.Keys) && e.HoldsOn(callSt', md)
+          ensures st' in context.AdjustedModels(md) 
+          {
+            forall v <- args.OutArgs() 
+              ensures v in context_in.AdjustState(st).Keys {
+              args.OutArgsDepthLemma();
+            }
+            var st'' := st + map v | v in vsNew.Keys :: st'[vsNew[v]]; //  var st'' := st.UpdateMapShift(vNew, map i: Idx | i in args.OutArgs() :: st'[i]);
+            assert st' == context.AdjustState(st'');
+            var callSt' := args.Eval(st') /*+ args.EvalOld(stAdj)*/;
+            assert context.IsSatisfiedOn(st'', md) by {
+              assert context.incarnation.Values <= st''.Keys;
+              forall e <- context.ctx
+                ensures e.IsDefinedOn(st''.Keys)
+                ensures e.HoldsOn(st'', md) {
+                if e in context_in.ctx {
+                  e.EvalFVarsLemma(st, st'', md);
+                } else {
+                  assert e in contextPost.SeqSubstitute(proc.Post);
+                  var e' := contextPost.GetSeqSubstituteLemma(proc.Post, e);
+                  forall i <- contextPost.incarnation.Values
+                    ensures i in st''.Keys {
+                    context'.mkPostContextIncrSubsetLemma(proc, args, /*context_in,*/ i);
+                  }
+                  contextPost.SubstituteIsDefinedOnLemma(e', st''.Keys);
+                  calc {
+                    contextPost.Substitute(e').HoldsOn(st'', md);
+                    { contextPost.AdjustStateSubstituteLemma(st'', e', md); }
+                    e'.HoldsOn(contextPost.AdjustState(st''), md);
+                    { 
+                      assert contextPost.AdjustState(st'') == callSt' by {
+                        assert contextPost.AdjustState(st'').Keys == callSt'.Keys == args.FVars(); /*+ args.NumInOutArgs()*/
+      //                   forall i | 0 <= i < |args| + args.NumInOutArgs() 
+      //                     ensures (contextPost.AdjustState(st''))[i] == callSt'[i] {
+      //                     if i < |args| {
+      //                       calc {
+      //                         (contextPost.AdjustState(st''))[i];
+      //                         == { args.IsDefinedOnIn(args[i], |context'.incarnation|);
+      //                               assert context'.incarnation[args[i].v] in context'.incarnation; }
+      //                         st''[context'.incarnation[args[i].v]];
+      //                         ==
+      //                         args.Eval(st')[i];
+      //                         ==
+      //                         callSt'[i];
+      //                       }
+      //                     } else {
+      //                       calc {
+      //                         (contextPost.AdjustState(st''))[i];
+      //                       == { assert contextPost.incarnation[i] in contextPost.incarnation; }
+      //                         st''[contextPost.incarnation[i]];
+      //                       == { args.InOutArgsLemma(args.InOutArgs()[i - |args|]);
+      //                             args.IsDefinedOnIn(InOutArgument(args.InOutArgs()[i - |args|]), |context_in.incarnation|);
+      //                           assert contextPost.incarnation[i] == context_in.incarnation[args.InOutArgs()[i - |args|]]; }
+      //                         st''[context_in.incarnation[args.InOutArgs()[i - |args|]]];
+      //                       ==
+      //                         args.EvalOld(context_in.AdjustState(st))[i - |args|];
+      //                       ==
+      //                         callSt'[i];
+      //                       }
+                          // }
+                        // }
+                      } 
+                    }
+                    true;
+                  }
+                }
+              }
+            }
+          }
+      }
+  }
+
+  ghost function BlockWPSeq(bcont: Block.Continuation, post: iset<State>, md: M.Model) : Omni.Continuation
+    ensures |BlockWPSeq(bcont, post, md)| == |bcont| + 1
+    // reads *
+  {
+    if bcont == [] then
+      [post]
+    else 
+      var wpSeq := BlockWPSeq(bcont[1..], post, md); // [AllStates]
+      var wpNew := Omni.SeqWP(bcont[0].cont, wpSeq, md); // Omni.SeqWP(Checks, [AllStates])
+      var wpSeq := wpSeq.UpdateHead(wpNew); // [Omni.SeqWP(Checks, [AllStates])]
+      wpSeq.UpdateAndAdd(bcont[0].varsInScope) 
+  }
+
+  lemma BlockWPSeqIdx(bcont: Block.Continuation, l: nat, md: M.Model)
+    requires l < |bcont|
+    ensures BlockWPSeq(bcont, AllStates, md)[l + 1] == UpdateSet(bcont.VarsInScope(l), BlockWPSeq(bcont[l..], AllStates, md)[0])
+  {
+    if l != 0 {
+      if |bcont| != 0 {
+        var blockWP := BlockWPSeq(bcont[1..], AllStates, md);
+        calc {
+          BlockWPSeq(bcont, AllStates, md)[l + 1];
+        ==
+          blockWP.UpdateHead(Omni.SeqWP(bcont[0].cont, blockWP, md)).UpdateAndAdd(bcont[0].varsInScope)[l + 1];
+        ==
+          blockWP.UpdateHead(Omni.SeqWP(bcont[0].cont, blockWP, md)).Update(bcont[0].varsInScope)[l];
+        == 
+          UpdateSet(bcont[0].varsInScope, blockWP.UpdateHead(Omni.SeqWP(bcont[0].cont, blockWP, md))[l]);
+        == { assert blockWP.UpdateHead(Omni.SeqWP(bcont[0].cont, blockWP, md))[l] == blockWP[l]; }
+          UpdateSet(bcont[0].varsInScope, blockWP[l]);
+        == 
+          { assert blockWP[l] == UpdateSet(bcont[1..].VarsInScope(l - 1), BlockWPSeq(bcont[l..], AllStates, md)[0]) by {
+            assert bcont[1..][l - 1..] == bcont[l..];
+            BlockWPSeqIdx(bcont[1..], l - 1, md); 
+          } }
+          UpdateSet(bcont[0].varsInScope, UpdateSet(bcont[1..].VarsInScope(l - 1), BlockWPSeq(bcont[l..], AllStates, md)[0]));
+        == { assert bcont.VarsInScope(l) == bcont[0].varsInScope + bcont[1..].VarsInScope(l - 1);
+             assert forall st: State :: st.Without(bcont.VarsInScope(l)) == st.Without(bcont[0].varsInScope).Without(bcont[1..].VarsInScope(l - 1)); }
+          UpdateSet(bcont.VarsInScope(l), BlockWPSeq(bcont[l..], AllStates, md)[0]);
+          }
+        }
+    } else {
+      calc {
+        UpdateSet(bcont.VarsInScope(0), BlockWPSeq(bcont[0..], AllStates, md)[0]);
+      == { assert forall st: State :: st.Without({}) == st; }
+        BlockWPSeq(bcont, AllStates, md)[0];
+      ==
+        BlockWPSeq(bcont, AllStates, md)[1];
+      }
+    }
+  }
+
+  ghost predicate BlockSem(s: seq<Stmt>, bcont: Block.Continuation, st: State, post: iset<State>, md: M.Model) 
+  {
+    Omni.SeqSem(s, st, BlockWPSeq(bcont, post, md), md)
+  }
+
+  lemma BlockLastPost(bcont: Block.Continuation, st: State, md: M.Model)  
+    requires |bcont| > 0
+    requires bcont[|bcont| - 1] == Block.Point([], {}) 
+    ensures st in BlockWPSeq(bcont, AllStates, md)[|bcont|]
+  {
+    BlockWPSeqIdx(bcont, |bcont| - 1, md);
+  }
+
+  lemma IsDefinedLoop(inv: Expr, body: Stmt, vars : set<Variable>, k: nat)
+    requires body.ValidCalls()
+    requires Loop(inv, body).IsDefinedOn(vars)
+    requires Loop(inv, body).JumpsDefinedOn(k)
+    ensures SeqIsDefinedOn([Assume(inv), body, Check(inv), Assume(BConst(false))], vars)
+    ensures SeqJumpsDefinedOn([Assume(inv), body, Check(inv), Assume(BConst(false))], k)
+  {
+    assert [Assume(inv), body, Check(inv), Assume(BConst(false))][0] == Assume(inv);
+    assert [Assume(inv), body, Check(inv), Assume(BConst(false))][1..] == [body, Check(inv), Assume(BConst(false))];
+    assert [body, Check(inv), Assume(BConst(false))][0] == body;
+    assert [body, Check(inv), Assume(BConst(false))][1..] == [Check(inv), Assume(BConst(false))];
+    assert [Check(inv), Assume(BConst(false))][0] == Check(inv);
+    assert [Check(inv), Assume(BConst(false))][1..] == [Assume(BConst(false))];
+    assert [Assume(BConst(false))][0] == Assume(BConst(false));
+    assert [Assume(BConst(false))][1..] == [];
+  }
+
+  // We need add allocated variables to be distinct. Otherwise, when we deallocate a variable,
+  // we may delete a variable that is still in use. This is bad because we can delete an incarnation
+  // that is still needed.
+  method SeqVCGen(s: seq<Stmt>, context: Context, bcont: Block.Continuation) returns (VCs: seq<Expr>) 
+    requires SeqValidCalls(s)
+    requires bcont.ValidCalls()
+    requires bcont.IsDefinedOn(context.incarnation.Keys)
+
+    requires SeqIsDefinedOn(s, context.incarnation.Keys)
+    requires SeqJumpsDefinedOn(s, |bcont|)
+
+    requires bcont.VarsDefined(context.incarnation.Keys)
+    requires bcont.JumpsDefined()
+
+    requires SeqVariablesDistinct(s, context.incarnation.Keys)
+    requires bcont.VariablesDistinct(context.incarnation.Keys)
+
+    decreases SeqSize(s) + bcont.Size()
+
+    ensures
+      forall md: M.Model ::
+        SeqIsSafe(s, md) ==>
+        bcont.IsSafe(md) ==>
+        SeqHolds(VCs, md) ==> 
+          forall st: State:: 
+            context.IsSatisfiedOn(st, md) ==> 
+            BlockSem(s, bcont, context.AdjustState(st), AllStates, md)
+  {
+    if s == [] { 
+      if bcont == [] {
+        VCs := [];
+        return;
+      } else {
+        var varsToDelete := bcont[0].varsInScope;
+        var cont := bcont[0].cont;
+        var context' := context.Delete(varsToDelete);
+        VCs := SeqVCGen(cont, context', bcont[1..]) by {
+          assert bcont.VarsInScope(1) == bcont[0].varsInScope;
+          bcont.VariablesDistinctDisjoint(context.incarnation.Keys, 0);
+          bcont.VariablesDistinctPrefix(context.incarnation.Keys, 1);
+        }
+        forall md: M.Model, st: State | 
+          && SeqIsSafe([], md)
+          && SeqHolds(VCs, md)
+          && bcont.IsSafe(md)
+          && context.IsSatisfiedOn(st, md)
+          ensures BlockSem([], bcont, context.AdjustState(st), AllStates, md) 
+        {
+          assert bcont[1..].IsSafe(md);
+          assert forall i <- context'.incarnation :: i in context.incarnation;
+          assert context'.AdjustState(st) == context.AdjustState(st).Without(varsToDelete);
+        }
+      }
+    } else {
+      var stmt, cont := s[0], s[1..];
+      assert s == [stmt] + cont;
+      SeqSizeSplitLemma(s);
+      SeqFunConcatLemmas([stmt], cont);
+      if stmt.Single() {
+        var VCstmt, VCcont, context';
+        context', VCstmt := VCGen(stmt, context);
+        VCcont := SeqVCGen(cont, context', bcont) by {
+          // bcont.VariablesDistinctDisjointTransitivity(context.incarnation.Keys, SeqBVars(cont), SeqBVars(s));
+          // bcont.VarsDefinedTransitivity(context.incarnation.Keys, context'.incarnation.Keys);
+        }
+        VCs := VCstmt + VCcont;
+        forall md: M.Model, st: State | 
+          && SeqIsSafe(s, md)
+          && SeqHolds(VCs, md)
+          && bcont.IsSafe(md)
+          && context.IsSatisfiedOn(st, md)
+          ensures BlockSem(s, bcont, context.AdjustState(st), AllStates, md) 
+        {
+          assert SeqHolds(VCstmt, md);
+          assert SeqHolds(VCcont, md);
+        }
+      } else {
+        match stmt
+        case Seq(ss) =>
+          VCs := SeqVCGen(ss + cont, context, bcont) by {
+            assert Seq(ss).ValidCalls();
+            // decreases
+            SeqFunConcatLemmas(ss, cont);
+            // SeqVariablesDistinct
+            SeqVariablesDistinctSeq(ss, cont, context.incarnation.Keys);
+          }
+          forall md: M.Model, st: State | 
+            && SeqIsSafe(s, md)
+            && SeqHolds(VCs, md)
+            && bcont.IsSafe(md)
+            && context.IsSatisfiedOn(st, md)
+            ensures BlockSem(s, bcont, context.AdjustState(st), AllStates, md) 
+          {
+            SeqIsSafeSeq(ss, cont, md);
+            Omni.SeqLemma(ss, cont, context.AdjustState(st), BlockWPSeq(bcont, AllStates, md), md);
+          }
+        case Choice(ss0, ss1) =>
+          var VCs0 := SeqVCGen([ss0] + cont, context, bcont) by {
+            assert Choice(ss0, ss1).ValidCalls();
+            // SeqVariablesDistinct
+            SeqVariablesDistinctChoice(ss0, ss1, cont, context.incarnation.Keys);
+            // VariablesDistinct
+            // bcont.VariablesDistinctDisjointTransitivity(context.incarnation.Keys, SeqBVars([ss0] + cont), SeqBVars(s));
+          }
+          var VCs1 := SeqVCGen([ss1] + cont, context, bcont) by {
+            assert Choice(ss0, ss1).ValidCalls();
+            // SeqVariablesDistinct
+            SeqVariablesDistinctChoice(ss0, ss1, cont, context.incarnation.Keys);
+            // VariablesDistinct
+            // bcont.VariablesDistinctDisjointTransitivity(context.incarnation.Keys, SeqBVars([ss1] + cont), SeqBVars(s));
+          }
+          VCs := VCs0 + VCs1;
+          forall md: M.Model, st: State | 
+            && SeqIsSafe(s, md)
+            && SeqHolds(VCs, md)
+            && bcont.IsSafe(md)
+            && context.IsSatisfiedOn(st, md)
+            ensures BlockSem(s, bcont, context.AdjustState(st), AllStates, md) 
+          { 
+            ChoiceIsSafe(ss0, ss1, cont, md);
+            assert SeqHolds(VCs0, md);
+            assert SeqHolds(VCs1, md);
+          }
+        case NewScope(vars, body) =>
+          var vsNew, context' := context.AddVarSet(vars);
+          assert vsNew.Values !! context.incarnation.Keys by {
+            assert NewScope(vars, body) in [NewScope(vars, body)] + cont;
+            assert NewScope(vars, body).VariablesDistinct(context.incarnation.Keys);
+          }
+          VCs := SeqVCGen([body], context', bcont.Update(cont, vars)) by {
+            // decreases
+            bcont.UpdateSize(cont, vars);
+            assert SeqSize([body]) == body.Size();
+            // ValidCalls
+            assert NewScope(vars, body).ValidCalls();
+            // SeqVariablesDistinct
+            SeqVariablesDistinctUnion([body], context'.incarnation.Keys, vars) by {
+              SeqVariablesDistinctNewScope(body, vars, cont, context.incarnation.Keys);
+            }
+            // VariablesDistinct
+            assert bcont.Update(cont, vars).VariablesDistinct(context'.incarnation.Keys) by {
+              reveal bcont.Update(cont, vars).VariablesDistinct;
+            }
+          }
+          forall md: M.Model, st: State | 
+            && SeqIsSafe(s, md)
+            && SeqHolds(VCs, md)
+            && bcont.IsSafe(md)
+            && context.IsSatisfiedOn(st, md)
+            ensures BlockSem(s, bcont, context.AdjustState(st), AllStates, md) 
+          {
+            NewScopeIsSafe(vars, body, cont, md);
+            var blockWP := BlockWPSeq(bcont, AllStates, md);
+            var contWP := Omni.SeqWP(cont, blockWP, md);
+            var updWP := ([contWP] + blockWP.UpdateHead(contWP)).Update(vars);
+            assert Omni.Sem(NewScope(vars, body), context.AdjustState(st), blockWP.UpdateHead(contWP), md) by {
+              forall vs: State | vs.Keys == vars
+                ensures Omni.Sem(body, context.AdjustState(st).Update(vs as map), blockWP.UpdateHead(contWP).UpdateAndAdd(vars), md) {
+                var st' := st + vs;
+                assert context'.IsSatisfiedOn(st', md) by {
+                  forall e: Expr | e in context.ctx && e.HoldsOn(st, md) {
+                    e.EvalFVarsLemma(st, st', md);
+                  }
+                }
+                calc {
+                  Omni.SeqSem([body], context'.AdjustState(st'), updWP, md);
+                  { assert context.AdjustState(st).Update(vs as map) == context'.AdjustState(st'); }
+                  Omni.SeqSem([body], context.AdjustState(st).Update(vs as map), updWP, md);
+                ==> { Omni.SeqSemSingle(body, context.AdjustState(st).Update(vs as map), updWP, md); }
+                  Omni.Sem(body, context.AdjustState(st).Update(vs as map), updWP, md);
+                }
+              }
+            }
+            Omni.SemNest(NewScope(vars, body), cont, context.AdjustState(st), blockWP, md);
+          }
+        case Escape(l) => 
+          var bcont' := bcont.Update(cont, {});
+          var varsToDelete := bcont'.VarsInScope(l);
+          var context' := context.Delete(varsToDelete) by {
+            bcont'.VarsInScopeLeqAll(l);
+          }
+          VCs := SeqVCGen([], context', bcont'[l..]) by {
+            // decreases
+            bcont'.SizePrefix(l);
+            // IsDefinedOn
+            assert bcont'[l..].IsDefinedOn(context'.incarnation.Keys) by {
+              if l != 0 {
+                assert bcont'[l..] == bcont[l - 1..] by {
+                  assert bcont' == [Block.Point(cont, {} as set<Variable>)] + bcont;
+                }
+                assert context'.incarnation.Keys == context.incarnation.Keys - varsToDelete;
+                bcont.VarsInScopeSuffix(l - 1);
+                assert varsToDelete == bcont[..l - 1].AllVarsInScope();
+                bcont.VariablesDistinctPrefix(context.incarnation.Keys, l - 1);
+              } else {
+                assert forall vs: set<Variable> :: vs - {} == vs;
+              }
+            }
+            // JumpsDefined
+            assert bcont'[l..].JumpsDefined() && bcont'[l..].VarsDefined(context'.incarnation.Keys) by {
+              if l != 0 {
+                assert bcont'[l..] == bcont[l - 1..];
+                assert context'.incarnation.Keys == context.incarnation.Keys - varsToDelete;
+                bcont.VarsInScopeSuffix(l - 1);
+                assert varsToDelete == bcont[..l - 1].AllVarsInScope();
+                bcont.DefinedPrefix(l - 1, context.incarnation.Keys);
+              } else {
+                assert forall vs: set<Variable> :: vs - {} == vs;
+              }
+            }
+            assert bcont'[l..].VariablesDistinct(context'.incarnation.Keys) by {
+             if l != 0 {
+                assert bcont'[l..] == bcont[l - 1..];
+                assert context'.incarnation.Keys == context.incarnation.Keys - varsToDelete;
+                bcont.VarsInScopeSuffix(l - 1);
+                assert varsToDelete == bcont[..l - 1].AllVarsInScope();
+                bcont.VariablesDistinctPrefix(context.incarnation.Keys, l - 1);
+              } else {
+                calc {
+                  bcont'[l..].VariablesDistinct(context'.incarnation.Keys);
+                  { assert context.incarnation.Keys - {} == context.incarnation.Keys; }
+                  bcont'.VariablesDistinct(context.incarnation.Keys);
+                  { reveal bcont'.VariablesDistinct;
+                    assert context.incarnation.Keys - {} == context.incarnation.Keys;
+                    assert bcont'[1..] == bcont; }
+                  true;
+                }
+              }
+            }
+          }
+          forall md: M.Model, st: State | 
+            && SeqHolds(VCs, md)
+            && bcont.IsSafe(md)
+            && SeqIsSafe(s, md)
+            && context.IsSatisfiedOn(st, md)
+            ensures Omni.SeqSem([Escape(l)] + cont, context.AdjustState(st), BlockWPSeq(bcont, AllStates, md), md) 
+          {
+            assert bcont'[l..].IsSafe(md);
+            Omni.SemNest(Escape(l), cont, context.AdjustState(st), BlockWPSeq(bcont, AllStates, md), md) by {
+              var blockWP := BlockWPSeq(bcont, AllStates, md);
+              var updBlockWP := blockWP.UpdateHead(Omni.SeqWP(cont, blockWP, md));
+              calc {
+                context.AdjustState(st) in updBlockWP[l];
+                { if l != 0 { BlockWPSeqIdx(bcont, l - 1, md); }
+                  assert UpdateSet(bcont'.VarsInScope(l), BlockWPSeq(bcont'[l..], AllStates, md)[0]) == updBlockWP[l] by {
+                  if l != 0 {
+                    // calc {
+                    //   updBlockWP[l];
+                    //   ==
+                    //   blockWP[l];
+                      BlockWPSeqIdx(bcont, l - 1, md);
+                      // UpdateSet(bcont.VarsInScope(l - 1), BlockWPSeq(bcont[l - 1..], AllStates, md)[0]);
+                      assert bcont.VarsInScope(l - 1) == bcont'.VarsInScope(l) by {
+                            bcont.VarsInScopeSuffix(l - 1); bcont'.VarsInScopeSuffix(l); }
+                      // UpdateSet(bcont'.VarsInScope(l), BlockWPSeq(bcont'[l..], AllStates, md)[0]);
+                    // }
+                  } else {
+                    assert forall st: State :: st.Without({}) == st;
+                  } 
+                } }
+                context.AdjustState(st) in UpdateSet(bcont'.VarsInScope(l), BlockWPSeq(bcont'[l..], AllStates, md)[0]);
+                context.AdjustState(st).Without(bcont'.VarsInScope(l)) in BlockWPSeq(bcont'[l..], AllStates, md)[0];
+                { assert context'.AdjustState(st) == context.AdjustState(st).Without(bcont'.VarsInScope(l)); }
+                context'.AdjustState(st) in BlockWPSeq(bcont'[l..], AllStates, md)[0];
+                { assert context'.IsSatisfiedOn(st, md) by {
+                  forall i | i in context'.incarnation.Values ensures i in st.Keys {
+                    assert i in context.incarnation.Values;
+                } } }
+                true;
+              }
+            }
+          }
+        case Loop(inv, body) =>
+          var VCInvIni := context.MkEntailment(inv);
+          var assnvars := AssignmentTarget.Process(body) by {
+            assert Loop(inv, body).ValidCalls();
+          }
+
+          var vsNew, context' := context.AddVarSet(assnvars);
+
+          var VCInvLoop := SeqVCGen([Assume(inv), body, Check(inv), Assume(BConst(false))], context', bcont) by {
+            // decreases
+            calc {
+              SeqSize([Assume(inv), body, Check(inv), Assume(BConst(false))]);
+            == 
+              1 + SeqSize([body, Check(inv), Assume(BConst(false))]);
+            ==
+              1 + body.Size() + SeqSize([Check(inv), Assume(BConst(false))]);
+            == 
+              1 + body.Size() + 1 + SeqSize([Assume(BConst(false))]);
+            == 
+              1 + body.Size() + 1 + 1 + SeqSize([]);
+            }
+            // ValidCalls
+            assert Loop(inv, body).ValidCalls();
+            // IsDefinedOn
+            IsDefinedLoop(inv, body, context'.incarnation.Keys, |bcont|);
+            // VarsDefined
+            assert bcont.VarsDefined(context'.incarnation.Keys) by {
+              assert context'.incarnation.Keys == context.incarnation.Keys;
+            }
+            // VariablesDistinct
+            assert bcont.VariablesDistinct(context'.incarnation.Keys) by {
+              assert context'.incarnation.Keys == context.incarnation.Keys;
+            }
+            // SeqVariablesDistinct
+            assert SeqVariablesDistinct([Assume(inv), body, Check(inv), Assume(BConst(false))], context'.incarnation.Keys) by {
+              assert context'.incarnation.Keys == context.incarnation.Keys;
+              SeqVariablesDistinctLoop(body, inv, cont, context.incarnation.Keys);
+            }
+          }
+          VCs := [VCInvIni] + VCInvLoop;
+          forall md: M.Model, st: State | 
+            && SeqIsSafe(s, md)
+            && SeqHolds(VCs, md)
+            && context.IsSatisfiedOn(st, md)
+            && bcont.IsSafe(md)
+            ensures Omni.SeqSem([Loop(inv, body)] + cont, context.AdjustState(st), BlockWPSeq(bcont, AllStates, md), md) 
+          {
+            LoopIsSafe(inv, body, cont, md);
+            forall st: State | context.IsSatisfiedOn(st, md)
+              ensures Omni.SeqSem([Loop(inv, body)] + cont, context.AdjustState(st), BlockWPSeq(bcont, AllStates, md), md) {
+              var inv'' := (inv.Sem(md) * context.AdjustState(st).EqExcept(assnvars));
+              var inv' := inv'' * iset st': State | context.incarnation.Keys <= st'.Keys;
+              var stt := context.AdjustState(st);
+              Omni.SemLoopWithCont(inv, body, cont, stt, BlockWPSeq(bcont, AllStates, md), inv', md) by {
+                assert stt in inv.Sem(md) by {
+                  context.MkEntailmentLemma(inv, st, md);
+                }
+
+                forall st': State | st' in inv'
+                  ensures Omni.Sem(body, st', BlockWPSeq(bcont, AllStates, md).UpdateHead(inv'), md) {
+                  var st'' := st + map v | v in vsNew.Keys :: st'[vsNew[v]];
+                  
+                  assert st' == context'.AdjustState(st'');
+
+                  assert context'.IsSatisfiedOn(st'', md) by {
+                    forall e <- context'.ctx 
+                      ensures e.HoldsOn(st'', md) {
+                      e.EvalFVarsLemma(st, st'', md);
+                    }
+                  }
+                  calc {
+                    Omni.Sem(body, st', BlockWPSeq(bcont, AllStates, md).UpdateHead(inv'), md);
+                    { SeqVariablesDistinctLoop(body, inv, cont, context.incarnation.Keys);
+                      Omni.SemFrameFirst(body, st', BlockWPSeq(bcont, AllStates, md), inv'', md, context.incarnation.Keys); }
+                    Omni.Sem(body, st', BlockWPSeq(bcont, AllStates, md).UpdateHead(inv''), md);
+                    { AssignmentTarget.Correct(body, st', context.AdjustState(st), assnvars, BlockWPSeq(bcont, AllStates, md), inv.Sem(md), md); }
+                    Omni.Sem(body, st', BlockWPSeq(bcont, AllStates, md).UpdateHead(inv.Sem(md)), md);
+                    { Omni.InvSem(inv, body, st', BlockWPSeq(bcont, AllStates, md), Assume(BConst(false)), md); }
+                    Omni.SeqSem([Assume(inv), body, Check(inv), Assume(BConst(false))], st', BlockWPSeq(bcont, AllStates, md), md);
+                    { assert SeqHolds(VCInvLoop, md); }
+                    true;
+                  }
+                }
+              }
+            }
+          }
+      }
+    }
+  }
+
+  method VCGenProc(proc: Procedure) returns (VCs: seq<Expr>) 
+    requires proc.Valid()
+    ensures forall md: M.Model ::
+      proc.IsSafe(md) ==>
+      (forall e <- VCs :: e.Holds(md)) ==> Omni.ProcedureIsSound(proc, md)
+  {
+    var context := mkInitialContext(proc);
+    var bcont: Block.Continuation := [Block.Point(proc.PostCheck(), {})];
+    if proc.Body.Some? {
+      VCs := SeqVCGen([proc.Body.value], context, bcont) by {
+        assert context.incarnation.Keys == proc.ParametersKeys();
+        calc {
+          bcont.VariablesDistinct(context.incarnation.Keys);
+          { assert context.incarnation.Keys == proc.ParametersKeys(); }
+          bcont.VariablesDistinct(proc.ParametersKeys());
+          { assert proc.ParametersKeys() - {} == proc.ParametersKeys();
+            reveal bcont.VariablesDistinct; }
+          SeqVariablesDistinct(proc.PostCheck(), proc.ParametersKeys());
+          true;
+        }
+      }
+      forall md: M.Model, st: State | 
+        && SeqHolds(VCs, md)
+        && proc.IsSafe(md)
+        && st in proc.PreSet(md)
+        ensures Omni.Sem(proc.Body.value, st, [proc.PostSet(md)], md) 
+      {
+        proc.IsSafePostCheckLemma(md);
+        assert context.IsSatisfiedOn(st, md);
+        assert Omni.Sem(proc.Body.value, context.AdjustState(st), BlockWPSeq(bcont, AllStates, md), md) by {
+          Omni.SeqSemSingle(proc.Body.value, context.AdjustState(st), BlockWPSeq(bcont, AllStates, md), md);
+        }
+        var wpSeq: Omni.Continuation := [Omni.SeqWP(proc.PostCheck(), [AllStates], md), Omni.SeqWP(proc.PostCheck(), [AllStates], md)];
+        assert BlockWPSeq(bcont, AllStates, md) == wpSeq by {
+          wpSeq.Update0();
+        }
+        Omni.SemConsDepthLemma(proc.Body.value, context.AdjustState(st), wpSeq, [proc.PostSet(md)], 0, md) by {
+          forall st: State | Omni.SeqSem(proc.PostCheck(), st, [AllStates], md)
+            ensures st in proc.PostSet(md) {
+            Omni.SemPostCheckLemma(proc, st, [AllStates], md);
+          }
+        }
+        assert context.AdjustState(st) == st;
+      }
+    } else {
+      VCs := [];
+    }
+  }
+
+// /*  
+//   e.HoldsWithAxiom(axioms) <==> "pick a A <= axioms", A => e
+
+//    + requires Axioms.Holds()
+//    ensures (forall e <- VCs :: e.HoldsAxioms(axioms)) ==> 
+//       forall proc <- procs :: Omni.RefProcedureIsSound(proc)
+//  */
+
+  method VCGenProcs(procs: seq<Procedure>, funcs: seq<Function>) returns (VCs: seq<Expr>)
+    requires forall proc <- procs :: proc.Valid()
+
+    requires forall proc <- procs :: proc.ProceduresCalled() <= SetOfSeq(procs)
+    requires forall func <- funcs :: func.FunctionsCalled() <= SetOfSeq(funcs)
+    requires forall proc <- procs :: proc.FunctionsCalled() <= SetOfSeq(funcs)
+    requires SeqSafeWith(procs, SetOfSeq(funcs))
+    ensures 
+      SeqRefHoldsWith(VCs, SetOfSeq(funcs)) ==> 
+        forall proc <- procs :: Omni.RefProcedureIsSoundWith(proc, SetOfSeq(funcs))
+  {
+    VCs := [];
+    var VCs';
+    for i := 0 to |procs| 
+      invariant forall md: M.Model :: 
+        ((forall proc <- procs :: proc.IsSafe(md)) &&
+        SeqHolds(VCs, md)) ==> forall proc <- procs[..i] :: Omni.ProcedureIsSound(proc, md)
+    {
+      VCs' := VCGenProc(procs[i]) by {
+        assert procs[i] in procs;
+      }
+      ghost var VCs'' := VCs;
+      VCs := VCs' + VCs;
+      forall md: M.Model | 
+        && (forall proc <- procs :: proc.IsSafe(md))
+        && SeqHolds(VCs, md)
+        ensures forall proc <- procs[..i + 1] :: Omni.ProcedureIsSound(proc, md)
+      {
+        assert SeqHolds(VCs', md);
+        assert SeqHolds(VCs'', md);
+        assert forall proc: Procedure | proc in procs[..i + 1] :: proc.IsSafe(md);
+      }
+    }
+    if SeqRefHoldsWith(VCs, SetOfSeq(funcs)) {
+      forall md: M.Model {:trigger} |
+        (forall func <- funcs :: func.IsSound(md)) 
+        ensures forall proc <- procs :: Omni.RefProcedureIsSound(proc, md) {
+        assert SeqRefHolds(VCs, md);
+        forall e <- VCs, st: State | e.IsDefinedOn(st.Keys) 
+          ensures e.HoldsOn(st, md) {
+          e.EvalComplete(st, iset{md.True()}, md);
+        }
+        assert SeqHolds(VCs, md);
+        Omni.SemSoundProcs(SetOfSeq(procs), SetOfSeq(funcs), md);
+      }
+    }
+  }
+}


### PR DESCRIPTION
In this PR we introduce a soundness proof for VC Generator. It adds `src/Sound/` folder with  
- `Data/` model of the B3-related data types, including `Data/Ast/` with B3 statements and expressions and `Data/State` with notion of B3 state
- `Semantics/` formalisation of `B3` semantics
- `VCGen/` formalisation of VC generator. This folder mimics the content of `scr/Verifier` folder, including implementations and proofs for block continuations, assignment targets, incarnations, and VC generator itself.

PS: I merge everything in one commit because otherwise I have some weird rebase conflicts (my commit mesages are not informative anyway)